### PR TITLE
discovery: support walking up the tree

### DIFF
--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -84,7 +84,7 @@ func runFetch(args []string) (exit int) {
 	for _, img := range args {
 		hash, err := fetchImage(img, ds)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v", err)
+			fmt.Fprintf(os.Stderr, "%v\n", err)
 			return 1
 		}
 		fmt.Println(hash)


### PR DESCRIPTION
Now we can host the meta tags on the root domain of a site. For example
for etcd we can put meta tags such as this on coreos.com:

```
<meta name="ac-discovery" content="coreos.com/etcd https://github.com/coreos/etcd/releases/download/{version}/etcd-{version}-{os}-{arch}.{ext}">
```

And this will work even though we don't have an index at coreos.com/etcd

And a client can simply do:

```
rkt run coreos.com/etcd:v0.5.0-alpha.4
```

The previous behavior would have gotten the 404 on https://coreos.com/etcd and stopped.