### PR TITLE
rkt: merge global flags into command flags

### DIFF
--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -68,6 +68,9 @@ func main() {
 	for _, c := range commands {
 		if c.Name == args[0] {
 			cmd = c
+			globalFlagset.VisitAll(func(f *flag.Flag) {
+				c.Flags.Var(f.Value, f.Name, f.Usage)
+			})
 			if err := c.Flags.Parse(args[1:]); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(2)


### PR DESCRIPTION
This is a dumb strawman hack to make working with global args a little less fussy, e.g. now you can do
	`rkt run -debug ...`
instead of always having to remember
	`rkt -debug run ...`

It also means that all the global args show up in the --help for subcommands