### PR TITLE
Restore files and directories times (access and modification times).

### DIFF
--- a/pkg/tar/utimes_linux.go
+++ b/pkg/tar/utimes_linux.go
@@ -1,0 +1,43 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These functions are from github.com/docker/docker/pkg/system
+
+// TODO(sgotti) waiting for a utimensat functions accepting flags and a
+// LUtimesNano using it in https://github.com/golang/sys/
+
+package tar
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	// These are not currently available in syscall
+	AT_FDCWD := -100
+	AT_SYMLINK_NOFOLLOW := 0x100
+
+	var _path *byte
+	_path, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	if _, _, err := syscall.Syscall6(syscall.SYS_UTIMENSAT, uintptr(AT_FDCWD), uintptr(unsafe.Pointer(_path)), uintptr(unsafe.Pointer(&ts[0])), uintptr(AT_SYMLINK_NOFOLLOW), 0, 0); err != 0 && err != syscall.ENOSYS {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/tar/utimes_unsupported.go
+++ b/pkg/tar/utimes_unsupported.go
@@ -1,0 +1,25 @@
+// +build !linux
+
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These functions are from github.com/docker/docker/pkg/system
+
+package tar
+
+import "syscall"
+
+func LUtimesNano(path string, ts []syscall.Timespec) error {
+	return ErrNotSupportedPlatform
+}


### PR DESCRIPTION
This pull request depends on #275.

As the syscalls to restore a symlink modification times are not available (os.Chtime changes the linked file times) I used the github.com/docker/pkg/system that contains this functions and many other that can be very useful and tests (for example makeblockdev can be replaced with system.Mknod and used for various os).