### PR TITLE
stage1/rootfs: various small Makefile dependency fixups

### DIFF
--- a/stage1/rootfs/Makefile
+++ b/stage1/rootfs/Makefile
@@ -10,7 +10,6 @@ $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
 
 clean: $(SUBDIRS)
-	rm -Rf $(S1) $(S1TAR)
 
 test: $(SUBDIRS)
 

--- a/stage1/rootfs/aggregate/Makefile
+++ b/stage1/rootfs/aggregate/Makefile
@@ -2,13 +2,13 @@ S1=s1rootfs
 S1TAR=$(S1).tar
 
 ../../../stage0/stage1_rootfs/bin.go: $(S1TAR) Makefile
-	@mkdir -p $$(dirname $@)
+	@mkdir -p $$(dirname $@)					&& \
 	TMP=$$(mktemp -d -t stage1-XXXXXX)				&& \
 	ln -s "$(CURDIR)/$(S1TAR)" "$$TMP"				&& \
 	go-bindata -o $@ -prefix="$$TMP" -pkg=stage1_rootfs "$$TMP"	&& \
 	rm -Rf "$$TMP"
 
-$(S1TAR): aggregate.sh Makefile scripts/* units/*
+$(S1TAR): aggregate.sh Makefile scripts/* units/* install.d/*
 	@./aggregate.sh && tar cf $(S1TAR) -C $(S1) .
 
 .PHONY: clean

--- a/stage1/rootfs/aggregate/aggregate.sh
+++ b/stage1/rootfs/aggregate/aggregate.sh
@@ -2,34 +2,12 @@
 
 # aggregate everything into a single rootfs tree
 
-RD=s1rootfs
+ROOT=s1rootfs
 
 # always start over
-[ -e "$RD" ] && rm -Rf "$RD"
+[ -e "$ROOT" ] && rm -Rf "$ROOT"
 
-# start with the usr/rootfs
-cp -a ../usr/rootfs "$RD"
-
-# populate the systemd units
-install -d -m 0755 "$RD/usr/lib/systemd/system"
-install -d -m 0755 "$RD/usr/lib/systemd/system/default.target.wants"
-install -d -m 0755 "$RD/usr/lib/systemd/system/sockets.target.wants"
-install -m 0644 units/default.target "$RD/usr/lib/systemd/system"
-install -m 0644 units/exit-watcher.service "$RD/usr/lib/systemd/system"
-install -m 0644 units/local-fs.target "$RD/usr/lib/systemd/system"
-install -m 0644 units/reaper.service "$RD/usr/lib/systemd/system"
-install -m 0644 units/sockets.target "$RD/usr/lib/systemd/system"
-install -m 0755 scripts/reaper.sh "$RD"
-install -m 0755 ../shim/shim.so "$RD"
-install -m 0755 ../diagexec/diagexec "$RD"
-ln -s shim.so "$RD/fakesdboot.so"
-
-install -d "$RD/etc"
-echo "rocket" > "$RD/etc/os-release"
-
-# parent dir for the stage2 bind mounts
-install -d "$RD/opt/stage2"
-
-# dir for result code files
-install -d "$RD/rkt/status"
-
+# run everything in install.d/*
+for i in install.d/*; do
+	source "$i"
+done

--- a/stage1/rootfs/aggregate/install.d/99misc
+++ b/stage1/rootfs/aggregate/install.d/99misc
@@ -1,0 +1,19 @@
+# populate the systemd units
+install -d -m 0755 "$ROOT/usr/lib/systemd/system"
+install -d -m 0755 "$ROOT/usr/lib/systemd/system/default.target.wants"
+install -d -m 0755 "$ROOT/usr/lib/systemd/system/sockets.target.wants"
+install -m 0644 units/default.target "$ROOT/usr/lib/systemd/system"
+install -m 0644 units/exit-watcher.service "$ROOT/usr/lib/systemd/system"
+install -m 0644 units/local-fs.target "$ROOT/usr/lib/systemd/system"
+install -m 0644 units/reaper.service "$ROOT/usr/lib/systemd/system"
+install -m 0644 units/sockets.target "$ROOT/usr/lib/systemd/system"
+install -m 0755 scripts/reaper.sh "$ROOT"
+
+install -d "$ROOT/etc"
+echo "rocket" > "$ROOT/etc/os-release"
+
+# parent dir for the stage2 bind mounts
+install -d "$ROOT/opt/stage2"
+
+# dir for result code files
+install -d "$ROOT/rkt/status"

--- a/stage1/rootfs/diagexec/Makefile
+++ b/stage1/rootfs/diagexec/Makefile
@@ -1,8 +1,9 @@
 BIN=diagexec
 SRC=diagexec.c
 
-$(BIN): $(SRC) elf.h Makefile
+$(BIN): $(SRC) elf.h Makefile install
 	$(CC) $(CFLAGS) -o $@ $(SRC) -static -s
+	@cp install ../aggregate/install.d/10diagexec
 
 .PHONY: clean
 clean:

--- a/stage1/rootfs/diagexec/install
+++ b/stage1/rootfs/diagexec/install
@@ -1,0 +1,1 @@
+install -m 0755 ../diagexec/diagexec "$ROOT"

--- a/stage1/rootfs/shim/Makefile
+++ b/stage1/rootfs/shim/Makefile
@@ -1,8 +1,9 @@
 BIN=shim.so
 SRC=shim.c
 
-$(BIN): $(SRC) Makefile
+$(BIN): $(SRC) Makefile install
 	$(CC) $(CFLAGS) $(SRC) -o $(BIN) -shared -fPIC -Wl,--no-as-needed -ldl -lc
+	@cp install ../aggregate/install.d/10shim
 
 .PHONY: clean
 clean:

--- a/stage1/rootfs/shim/install
+++ b/stage1/rootfs/shim/install
@@ -1,0 +1,2 @@
+install -m 0755 ../shim/shim.so "$ROOT"
+ln -s shim.so "$ROOT/fakesdboot.so"

--- a/stage1/rootfs/usr/Makefile
+++ b/stage1/rootfs/usr/Makefile
@@ -1,11 +1,12 @@
 # base just derives a base root fs from a CoreOS image downloaded and verified
 
 
-usr.done: mkbase.sh cache/pxe.img
-	./mkbase.sh && touch usr.done
+usr.done: Makefile mkbase.sh cache/pxe.img manifest.d/* install
+	@./mkbase.sh && touch usr.done
+	@cp install ../aggregate/install.d/00usr
 
-cache/pxe.img: cache.sh
-	./cache.sh
+cache/pxe.img: Makefile cache.sh
+	@./cache.sh
 
 .PHONY: clean
 clean:

--- a/stage1/rootfs/usr/install
+++ b/stage1/rootfs/usr/install
@@ -1,0 +1,1 @@
+cp -a ../usr/rootfs "$ROOT"


### PR DESCRIPTION
 * usr/Makefile lacked dependency on manifest.d
 * aggregate/Makefile lacked dependency on discrete components:
   - Introduce aggregate/install.d registry of ordered component installers
   - Add Makefile dependency on aggregate/install.d/*
   - Amend discrete component's Makefiles to register their installation
     as aggregate/install.d/$prio$component scripts sourced by aggregate.sh

 These changes cause aggregate to occur when any discrete component is built
 in an incremental rootfs build.  Otherwise discrete components would be built
 without getting pulled into a (re)built rootfs.