### PR TITLE
doc: Add needed build programs and libraries.

### DIFF
--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -5,6 +5,9 @@
 ### Requirements
 
 * Linux 3.8+
+  * make
+  * gcc
+  * glibc development and static pieces (on Fedora/RHEL/Centos: glibc-devel and glibc-static packages, on Debian/Ubuntu libc6-dev package)
   * cpio
   * squashfs-tools
   * realpath


### PR DESCRIPTION
As the build process is going to build libraries and executables it requires:

* make
* gcc
* glibc development and static pieces.