### PR TITLE
added user and group for the example app

### DIFF
--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -55,6 +55,8 @@ Edit: manifest.json
         }
     ],
     "app": {
+        "user": "root",
+        "group": "root",
         "exec": [
             "/bin/hello"
         ],


### PR DESCRIPTION
if either user or group is missing, the actool validation would remind that's required:

$ actool -debug validate manifest.json
manifest.json: invalid ImageManifest: User is required
manifest.json: invalid ImageManifest: Group is required

Signed-off-by: Derek Ch <crquan@gmail.com>