### PR TITLE
stage1/init: quote Exec* argument lists

### DIFF
--- a/stage1/init/container_test.go
+++ b/stage1/init/container_test.go
@@ -1,0 +1,47 @@
+// Copyright 2014 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestQuoteExec(t *testing.T) {
+	tests := []struct {
+		input  []string
+		output string
+	}{
+		{
+			input:  []string{`path`, `"arg1"`, `"'arg2'"`, `'arg3'`},
+			output: `path "\"arg1\"" "\"\'arg2\'\"" "\'arg3\'"`,
+		}, {
+			input:  []string{`path`},
+			output: `path`,
+		}, {
+			input:  []string{`path`, ``, `arg2`},
+			output: `path "" "arg2"`,
+		}, {
+			input:  []string{`path`, `"foo\bar"`, `\`},
+			output: `path "\"foo\\bar\"" "\\"`,
+		},
+	}
+
+	for i, tt := range tests {
+		o := quoteExec(tt.input)
+		if o != tt.output {
+			t.Errorf("#%d: expected `%v` got `%v`", i, tt.output, o)
+		}
+	}
+}

--- a/test
+++ b/test
@@ -14,8 +14,8 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE_AND_FORMATTABLE="cas pkg/keystore pkg/lock pkg/tar"
-FORMATTABLE="$TESTABLE_AND_FORMATTABLE metadatasvc path pkg/io pkg/proc rkt stage0/run.go stage1 version"
+TESTABLE_AND_FORMATTABLE="cas pkg/keystore pkg/lock pkg/tar stage1/init"
+FORMATTABLE="$TESTABLE_AND_FORMATTABLE metadatasvc path pkg/io pkg/proc rkt stage0/run.go version"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then


### PR DESCRIPTION
Note this only quotes the arguments, not the path.  There's a bug in
systemd which prevents quoting the path; it thinks the executable's path
is not absolute when quoted.  This prevents things like an executable path
containing spaces from working.

Fixes #321.