### PR TITLE
update build script

### DIFF
--- a/build
+++ b/build
@@ -1,28 +1,15 @@
 #!/bin/bash -e
 
-ORG_PATH="github.com/coreos"
-REPO_PATH="${ORG_PATH}/rocket"
-
-if [ ! -h gopath/src/${REPO_PATH} ]; then
-	mkdir -p gopath/src/${ORG_PATH}
-	ln -s ../../../.. gopath/src/${REPO_PATH} || exit 255
-fi
-
-export GOBIN=${PWD}/bin
-export GOPATH=${GOPATH}:${PWD}/gopath
-
-eval $(go env)
-
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	echo "Building init (stage1)..."
-	go build -o $GOBIN/init ${REPO_PATH}/stage1/init
+	go build -o bin/init ./stage1/init
 
-	S1INIT=${PWD}/stage0/stage1_init
-	if [ $GOBIN/init -nt $S1INIT/bin.go ]; then
+	S1INIT=stage0/stage1_init
+	if [ bin/init -nt $S1INIT/bin.go ]; then
 		echo "Packaging init (stage1)..."
 		TMP=$(mktemp -d -t rocket-XXXXXX)
 		[ -d $S1INIT ] || mkdir -p $S1INIT
-		cp $GOBIN/init $TMP/s1init
+		cp bin/init $TMP/s1init
 		go-bindata -o $S1INIT/bin.go -pkg="stage1_init" -prefix=$TMP $TMP
 	fi
 
@@ -31,7 +18,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 fi
 
 echo "Building rkt (stage0)..."
-go build -o $GOBIN/rkt ${REPO_PATH}/rkt
+go build -o bin/rkt ./rkt
 
 echo "Building metadatasvc..."
-go build -o $GOBIN/metadatasvc ${REPO_PATH}/metadatasvc
+go build -o bin/metadatasvc ./metadatasvc

--- a/test
+++ b/test
@@ -33,9 +33,9 @@ else
 	FMT="$TEST"
 fi
 
-# split TEST into an array and prepend REPO_PATH to each local package
+# split TEST into an array and prepend ./ to each local package
 split=(${TEST// / })
-TEST=${split[@]/#/${REPO_PATH}/}
+TEST=${split[@]/#/./}
 
 echo "Running tests..."
 go test -timeout 60s ${COVER} $@ ${TEST} --race


### PR DESCRIPTION
remove useless ORG_PATH and REPO_PATH, no need to setup gopath

I don't understand why do you need to setup this ORG_PATH and REPO_PATH and gopath symlinks?
and if you actually build $GOBIN/init, it should be always newer than $S1INIT/bin.go, then why need that is file newer test?
the $OSTYPE is provided by bash not `go env`, I don't think go env variables are needed here.

Signed-off-by: Derek Ch <crquan@gmail.com>