### PR TITLE
rkt: version information is old/wrong

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.1.0"
+const Version = "0.1.1+git"


### PR DESCRIPTION
coreos-stable-00 rocket-v0.1.1 # ./rkt version
rkt version 0.1.0

coreos-stable-00 rocket-v0.1.1 # ./rkt help
NAME:
        rkt - rocket, the application container runner

USAGE: 
        rkt [global options] <command> [command options] [arguments...]

VERSION:
        0.1.0
