### PR TITLE
cas: add a tree store (#223)

### DIFF
--- a/cas/cas.go
+++ b/cas/cas.go
@@ -287,6 +287,11 @@ func (ds Store) RenderTreeStore(key string, rebuild bool) error {
 	return nil
 }
 
+// CheckTreeStore verifies the treestore consistency for the specified key.
+func (ds Store) CheckTreeStore(key string) error {
+	return ds.treestore.Check(key)
+}
+
 // GetTreeStorePath returns the absolute path of the treestore for the specified key.
 // It doesn't ensure that the path exists and is fully rendered. This should
 // be done calling IsRendered()

--- a/cas/tree.go
+++ b/cas/tree.go
@@ -1,0 +1,146 @@
+package cas
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+	"github.com/coreos/rocket/pkg/aci"
+)
+
+const (
+	hashfilename     = "hash"
+	renderedfilename = "rendered"
+)
+
+// TreeStore represents a store of rendered ACIs
+// The image's key becomes the name of the directory containing the rendered aci.
+type TreeStore struct {
+	path string
+}
+
+// Write renders the ACI with the provided key in the treestore
+// Write, to avoid having a rendered ACI with old stale files, requires that
+// the destination directory doesn't exist (usually Remove should be called
+// before Write)
+func (ts *TreeStore) Write(key string, ds *Store) error {
+	treepath := filepath.Join(ts.path, key)
+	fi, _ := os.Stat(treepath)
+	if fi != nil {
+		return fmt.Errorf("treestore: path %s already exists", treepath)
+	}
+	imageID, err := types.NewHash(key)
+	if err != nil {
+		return fmt.Errorf("treestore: cannot convert key to imageID: %v", err)
+	}
+	err = aci.RenderACIWithImageID(*imageID, treepath, ds)
+	if err != nil {
+		return fmt.Errorf("treestore: cannot render aci: %v", err)
+	}
+	// before creating the "rendered" flag file we need to ensure that all data is fsynced
+	err = filepath.Walk(treepath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsDir() && !info.Mode().IsRegular() {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		err = f.Sync()
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("treestore: failed to sync data: %v", err)
+	}
+	// Create rendered file
+	f, err := os.Create(filepath.Join(treepath, renderedfilename))
+	if err != nil {
+		return fmt.Errorf("treestore: failed to write rendered file: %v", err)
+	}
+	f.Close()
+
+	df, err := os.Open(treepath)
+	if err != nil {
+		return err
+	}
+	defer df.Close()
+	err = df.Sync()
+	if err != nil {
+		return fmt.Errorf("treestore: failed to sync tree store directory: %v", err)
+	}
+	return nil
+}
+
+// Remove cleans the directory for the specified key
+func (ts *TreeStore) Remove(key string) error {
+	treepath := filepath.Join(ts.path, key)
+	// If tree path doesn't exist we're done
+	_, err := os.Stat(treepath)
+	if err != nil && os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("treestore: failed to open tree store directory: %v", err)
+	}
+
+	renderedFilePath := filepath.Join(treepath, renderedfilename)
+	// The "rendered" flag file should be the firstly removed file. So if
+	// the removal ends with some error leaving some stale files IsRendered()
+	// will return false.
+	_, err = os.Stat(renderedFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if !os.IsNotExist(err) {
+		err := os.Remove(renderedFilePath)
+		// Ensure that the treepath directory is fsynced after removing the
+		// "rendered" flag file
+		f, err := os.Open(treepath)
+		if err != nil {
+			return fmt.Errorf("treestore: failed to open tree store directory: %v", err)
+		}
+		defer f.Close()
+		err = f.Sync()
+		if err != nil {
+			return fmt.Errorf("treestore: failed to sync tree store directory: %v", err)
+		}
+	}
+	return os.RemoveAll(treepath)
+}
+
+// IsRendered checks if the tree store is fully rendered
+func (ts *TreeStore) IsRendered(key string) (bool, error) {
+	// if the "rendered" flag file exists, assume that the store is already
+	// fully rendered.
+	treepath := filepath.Join(ts.path, key)
+	_, err := os.Stat(filepath.Join(treepath, renderedfilename))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// GetPath returns the absolute path of the treestore for the specified key.
+// It doesn't ensure that the path exists and is fully rendered. This should
+// be done calling IsRendered()
+func (ts *TreeStore) GetPath(key string) string {
+	return filepath.Join(ts.path, key)
+}
+
+// GetRootFS returns the absolute path of the rootfs for the specified key.
+// It doesn't ensure that the rootfs exists and is fully rendered. This should
+// be done calling IsRendered()
+func (ts *TreeStore) GetRootFS(key string) string {
+	return filepath.Join(ts.GetPath(key), "rootfs")
+}

--- a/cas/tree_test.go
+++ b/cas/tree_test.go
@@ -1,0 +1,132 @@
+package cas
+
+import (
+	"archive/tar"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/coreos/rocket/pkg/aci"
+)
+
+func treeStoreDSWriteACI(dir string, ds *Store) (string, error) {
+	imj := `
+		{
+		    "acKind": "ImageManifest",
+		    "acVersion": "0.4.1",
+		    "name": "example.com/test01"
+		}
+	`
+
+	entries := []*aci.ACIEntry{
+		// An empty dir
+		{
+			Header: &tar.Header{
+				Name:     "rootfs/a",
+				Typeflag: tar.TypeDir,
+			},
+		},
+		{
+			Contents: "hello",
+			Header: &tar.Header{
+				Name: "hello.txt",
+				Size: 5,
+			},
+		},
+		{
+			Header: &tar.Header{
+				Name:     "rootfs/link.txt",
+				Linkname: "rootfs/hello.txt",
+				Typeflag: tar.TypeSymlink,
+			},
+		},
+		// dangling symlink
+		{
+			Header: &tar.Header{
+				Name:     "rootfs/link2.txt",
+				Linkname: "rootfs/missingfile.txt",
+				Typeflag: tar.TypeSymlink,
+			},
+		},
+		{
+			Header: &tar.Header{
+				Name:     "rootfs/fifo",
+				Typeflag: tar.TypeFifo,
+			},
+		},
+	}
+	aci, err := aci.NewACI(dir, imj, entries)
+	if err != nil {
+		return "", err
+	}
+	defer aci.Close()
+
+	// Rewind the ACI
+	if _, err := aci.Seek(0, 0); err != nil {
+		return "", err
+	}
+
+	// Import the new ACI
+	key, err := ds.WriteACI(aci, false)
+	if err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+func TestTreeStoreWrite(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	key, err := treeStoreDSWriteACI(dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Ask the store to render the treestore
+	err = ds.treestore.Write(key, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTreeStoreRemove(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	key, err := treeStoreDSWriteACI(dir, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Test non existent dir
+	err = ds.treestore.Remove(key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Test rendered tree
+	err = ds.treestore.Write(key, ds)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = ds.treestore.Remove(key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cas/tree_test.go
+++ b/cas/tree_test.go
@@ -95,6 +95,12 @@ func TestTreeStoreWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
+	// Verify image Hash. Should be the same.
+	err = ds.treestore.Check(key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestTreeStoreRemove(t *testing.T) {


### PR DESCRIPTION
The last 4 commits are the relevant ones. The others are from #395 and #533.

As explained in #223 this PR adds a tree store.
The first patch provides the Write, Remove and GetRootFs functions
The second patch changes cas.WriteACI to call the tree store Write function (not sure if this should be done directly inside WriteACI or outside).

The third patch adds validity checking to the rendered ACI. As discussed in #223 using an archive/tar writer doesn't work as it doesn't create reproducible tars due to some maps in pax headers. This implementation uses a special writer the tries to keep a consistent fileinfo struct and write it (by now in json) and the file contents to an hash writer. There are some TODOs that needs some thoughts.

Thanks!