### PR TITLE
*: update and split out gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,4 @@
 bin/
 gopath/
-stage0/stage1_init/
-stage0/stage1_rootfs/
-stage1/cache/
-stage1/rootfs/aggregate/s1rootfs.tar
-stage1/rootfs/aggregate/s1rootfs/
-stage1/rootfs/shim/shim.so
-stage1/rootfs/usr/cache/
-stage1/rootfs/usr/manifest.txt
-stage1/rootfs/usr/rootfs/
-stage1/rootfs/usr/usr.done
-stage1/rootfs/usr/usr.squashfs
 *.sw[ponm]
 .DS_Store

--- a/stage0/.gitignore
+++ b/stage0/.gitignore
@@ -1,0 +1,2 @@
+stage1_init/
+stage1_rootfs/

--- a/stage1/.gitignore
+++ b/stage1/.gitignore
@@ -1,0 +1,12 @@
+cache/
+rootfs/aggregate/install.d/
+!rootfs/aggregate/install.d/99misc
+rootfs/aggregate/s1rootfs.tar
+rootfs/aggregate/s1rootfs/
+rootfs/diagexec/diagexec
+rootfs/shim/shim.so
+rootfs/usr/cache/
+rootfs/usr/manifest.txt
+rootfs/usr/rootfs/
+rootfs/usr/usr.done
+rootfs/usr/usr.squashfs


### PR DESCRIPTION
This wasn't catching some of the artefacts from the stage1 build process.
Also, .gitignore files can be more local to what they ipact so this creates
ones for the stage0/stage1 directories that should be updated inline with
changes to those packages.

/cc @vcaputo, seem OK to you?