### PR TITLE
Alban/list containers

### DIFF
--- a/rkt/containers.go
+++ b/rkt/containers.go
@@ -44,7 +44,7 @@ func getContainers() ([]string, error) {
 
 // getContainerLockAndState opens the container directory in the form of a lock.DirLock,
 // returning the lock and wether the container has already exited or not.
-func getContainerLockAndState(containerUUID *types.UUID) (l *lock.DirLock, isExited bool, err error) {
+func getContainerLockAndState(containerUUID *types.UUID, wait bool) (l *lock.DirLock, isExited bool, err error) {
 	cid := containerUUID.String()
 	isGarbage := false
 
@@ -67,7 +67,7 @@ func getContainerLockAndState(containerUUID *types.UUID) (l *lock.DirLock, isExi
 	}
 
 	isExited = true
-	if flagWait && !isGarbage {
+	if wait && !isGarbage {
 		err = l.SharedLock()
 	} else {
 		err = l.TrySharedLock()

--- a/rkt/containers.go
+++ b/rkt/containers.go
@@ -1,0 +1,90 @@
+// Copyright 2014-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/appc/spec/schema/types"
+	"github.com/coreos/rocket/pkg/lock"
+)
+
+// getContainers returns a slice representing the containers in the given rocket directory
+func getContainers() ([]string, error) {
+	cdir := containersDir()
+	ls, err := ioutil.ReadDir(cdir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read containers directory: %v", err)
+	}
+	var cs []string
+	for _, dir := range ls {
+		if !dir.IsDir() {
+			fmt.Fprintf(os.Stderr, "Unrecognized file: %q, ignoring", dir)
+			continue
+		}
+		cs = append(cs, dir.Name())
+	}
+	return cs, nil
+}
+
+// getContainerLockAndState opens the container directory in the form of a lock.DirLock,
+// returning the lock and wether the container has already exited or not.
+func getContainerLockAndState(containerUUID *types.UUID) (l *lock.DirLock, isExited bool, err error) {
+	cid := containerUUID.String()
+	isGarbage := false
+
+	cp := filepath.Join(containersDir(), cid)
+	l, err = lock.NewLock(cp)
+	if err == lock.ErrNotExist {
+		// Fallback to garbage/$cid if containers/$cid is missing, "rkt gc" renames exited containers to garbage/$cid.
+		isGarbage = true
+		cp = filepath.Join(garbageDir(), cid)
+		l, err = lock.NewLock(cp)
+	}
+
+	if err != nil {
+		if err == lock.ErrNotExist {
+			err = fmt.Errorf("container %v not found", cid)
+		} else {
+			err = fmt.Errorf("error opening lock: %v", err)
+		}
+		return
+	}
+
+	isExited = true
+	if flagWait && !isGarbage {
+		err = l.SharedLock()
+	} else {
+		err = l.TrySharedLock()
+		if err == lock.ErrLocked {
+			if isGarbage {
+				// Container is exited and being deleted, we can't reliably query its status, it's effectively gone.
+				err = fmt.Errorf("unable to query status: %q is being removed", cid)
+				return
+			}
+			isExited = false
+			err = nil
+		}
+	}
+
+	if err != nil {
+		err = fmt.Errorf("error acquiring lock: %v", err)
+	}
+
+	return
+}

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -81,24 +81,6 @@ func runGC(args []string) (exit int) {
 	return
 }
 
-// getContainers returns a slice representing the containers in the given rocket directory
-func getContainers() ([]string, error) {
-	cdir := containersDir()
-	ls, err := ioutil.ReadDir(cdir)
-	if err != nil {
-		return nil, fmt.Errorf("cannot read containers directory: %v", err)
-	}
-	var cs []string
-	for _, dir := range ls {
-		if !dir.IsDir() {
-			fmt.Fprintf(os.Stderr, "Unrecognized file: %q, ignoring", dir)
-			continue
-		}
-		cs = append(cs, dir.Name())
-	}
-	return cs, nil
-}
-
 // emptyGarbage discards sufficiently aged containers from garbageDir()
 func emptyGarbage(gracePeriod time.Duration) error {
 	g := garbageDir()

--- a/rkt/list-containers.go
+++ b/rkt/list-containers.go
@@ -1,0 +1,69 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/appc/spec/schema/types"
+)
+
+var (
+	cmdListContainers = &Command{
+		Name:    "list-containers",
+		Summary: "List rkt containers and their status",
+		Usage:   "UUID",
+		Run:     runListContainers,
+	}
+)
+
+func init() {
+	commands = append(commands, cmdListContainers)
+}
+
+func runListContainers(args []string) (exit int) {
+	cs, err := getContainers()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to get containers list: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(out, "CONTAINER\tSTATUS\n")
+	for _, c := range cs {
+		containerUUID, err := types.NewUUID(c)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Invalid UUID: %v\n", err)
+			return 1
+		}
+
+		l, exited, err := getContainerLockAndState(containerUUID, false)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to access container: %v\n", err)
+			continue
+		}
+		defer l.Close()
+
+		if exited {
+			fmt.Fprintf(out, "%s\texited\n", c)
+		} else {
+			fmt.Fprintf(out, "%s\trunning\n", c)
+		}
+	}
+	out.Flush()
+
+	return
+}

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -20,11 +20,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"syscall"
 
 	"github.com/appc/spec/schema/types"
-	"github.com/coreos/rocket/pkg/lock"
 )
 
 var (
@@ -59,7 +57,7 @@ func runStatus(args []string) (exit int) {
 		return 1
 	}
 
-	l, exited, err := getContainerLockAndState(containerUUID)
+	l, exited, err := GetContainerLockAndState(containerUUID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to access container: %v\n", err)
 		return 1
@@ -80,53 +78,6 @@ func runStatus(args []string) (exit int) {
 	}
 
 	return 0
-}
-
-// getContainerLockAndState opens the container directory in the form of a lock.DirLock,
-// returning the lock and wether the container has already exited or not.
-func getContainerLockAndState(containerUUID *types.UUID) (l *lock.DirLock, isExited bool, err error) {
-	cid := containerUUID.String()
-	isGarbage := false
-
-	cp := filepath.Join(containersDir(), cid)
-	l, err = lock.NewLock(cp)
-	if err == lock.ErrNotExist {
-		// Fallback to garbage/$cid if containers/$cid is missing, "rkt gc" renames exited containers to garbage/$cid.
-		isGarbage = true
-		cp = filepath.Join(garbageDir(), cid)
-		l, err = lock.NewLock(cp)
-	}
-
-	if err != nil {
-		if err == lock.ErrNotExist {
-			err = fmt.Errorf("container %v not found", cid)
-		} else {
-			err = fmt.Errorf("error opening lock: %v", err)
-		}
-		return
-	}
-
-	isExited = true
-	if flagWait && !isGarbage {
-		err = l.SharedLock()
-	} else {
-		err = l.TrySharedLock()
-		if err == lock.ErrLocked {
-			if isGarbage {
-				// Container is exited and being deleted, we can't reliably query its status, it's effectively gone.
-				err = fmt.Errorf("unable to query status: %q is being removed", cid)
-				return
-			}
-			isExited = false
-			err = nil
-		}
-	}
-
-	if err != nil {
-		err = fmt.Errorf("error acquiring lock: %v", err)
-	}
-
-	return
 }
 
 // printStatusAt prints the container's pid and per-app status codes

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -57,7 +57,7 @@ func runStatus(args []string) (exit int) {
 		return 1
 	}
 
-	l, exited, err := GetContainerLockAndState(containerUUID)
+	l, exited, err := getContainerLockAndState(containerUUID, flagWait)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to access container: %v\n", err)
 		return 1


### PR DESCRIPTION
This is an initial implementation of the list-containers subcommand for #162 .

It reuses GetContainers() that was initially implemented in the gc subcommand. I moved it to a separate pkg to reuse it in list-containers.

The columns are aligned with text/tabwriter.

It just shows dead or alive at the moment. The exit status is not yet implemented.

Example:
```
$ sudo ./bin/rkt list-containers
CONTAINER                           STATUS
1d25bfdf-5baa-4186-a0e3-c4f863086bca        dead
30875910-03d1-4c57-8e93-4f82609098f1        dead
3f38a8a0-9bfe-401f-8f23-c6e518e920b1        dead
5697672d-dd17-4fde-8395-d70ec02ca016        alive
```
