### PR TITLE
pkg/tar: add PathWhitelistMap to whitelist files for tar extraction.

### DIFF
--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -28,8 +28,13 @@ const DEFAULT_DIR_MODE os.FileMode = 0755
 
 type insecureLinkError error
 
+// Map of paths that should be whitelisted. The paths should be relative to the
+// root of the tar file and should be cleaned (for example using filepath.Clean)
+type PathWhitelistMap map[string]struct{}
+
 // ExtractTar extracts a tarball (from a tar.Reader) into the given directory
-func ExtractTar(tr *tar.Reader, dir string) error {
+// if pwl is not nil, only the paths in the map are extracted.
+func ExtractTar(tr *tar.Reader, dir string, pwl PathWhitelistMap) error {
 	um := syscall.Umask(0)
 	defer syscall.Umask(um)
 	for {
@@ -38,6 +43,12 @@ func ExtractTar(tr *tar.Reader, dir string) error {
 		case io.EOF:
 			return nil
 		case nil:
+			if pwl != nil {
+				relpath := filepath.Clean(hdr.Name)
+				if _, ok := pwl[relpath]; !ok {
+					continue
+				}
+			}
 			err = ExtractFile(tr, hdr, dir)
 			if err != nil {
 				return fmt.Errorf("error extracting tarball: %v", err)

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -102,7 +102,7 @@ func TestExtractTarInsecureSymlink(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 		defer os.RemoveAll(tmpdir)
-		err = ExtractTar(tr, tmpdir)
+		err = ExtractTar(tr, tmpdir, nil)
 		if _, ok := err.(insecureLinkError); !ok {
 			t.Errorf("expected insecureSymlinkError error")
 		}
@@ -189,7 +189,7 @@ func TestExtractTarFolders(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	defer os.RemoveAll(tmpdir)
-	err = ExtractTar(tr, tmpdir)
+	err = ExtractTar(tr, tmpdir, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -221,4 +221,66 @@ func TestExtractTarFolders(t *testing.T) {
 		t.Errorf("unexpected dir mode: %s", dirInfo.Mode())
 	}
 
+}
+
+func TestExtractTarPWL(t *testing.T) {
+	entries := []*testTarEntry{
+		{
+			header: &tar.Header{
+				Name:     "folder/",
+				Typeflag: tar.TypeDir,
+				Mode:     int64(0747),
+			},
+		},
+		{
+			contents: "foo",
+			header: &tar.Header{
+				Name: "folder/foo.txt",
+				Size: 3,
+			},
+		},
+		{
+			contents: "bar",
+			header: &tar.Header{
+				Name: "folder/bar.txt",
+				Size: 3,
+			},
+		},
+		{
+			header: &tar.Header{
+				Name:     "folder/symlink.txt",
+				Typeflag: tar.TypeSymlink,
+				Linkname: "folder/foo.txt",
+			},
+		},
+	}
+	testTarPath, err := newTestTar(entries)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.Remove(testTarPath)
+	containerTar, err := os.Open(testTarPath)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	tr := tar.NewReader(containerTar)
+	tmpdir, err := ioutil.TempDir("", "rocket-temp-dir")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	pwl := make(PathWhitelistMap)
+	pwl["folder/foo.txt"] = struct{}{}
+	err = ExtractTar(tr, tmpdir, pwl)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(tmpdir, "folder/*.txt"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Errorf("unexpected number of files found: %d, wanted 1", len(matches))
+	}
 }

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -230,7 +230,7 @@ func untarRootfs(r io.Reader, dir string) error {
 		return fmt.Errorf("error creating stage1 rootfs directory: %v", err)
 	}
 
-	if err := ptar.ExtractTar(tr, dir); err != nil {
+	if err := ptar.ExtractTar(tr, dir, nil); err != nil {
 		return fmt.Errorf("error extracting rootfs: %v", err)
 	}
 	return nil
@@ -304,7 +304,7 @@ func setupImage(cfg Config, img types.Hash, dir string) (*schema.ImageManifest, 
 	hash := sha512.New()
 	r := io.TeeReader(rs, hash)
 
-	if err := ptar.ExtractTar(tar.NewReader(r), ad); err != nil {
+	if err := ptar.ExtractTar(tar.NewReader(r), ad, nil); err != nil {
 		return nil, fmt.Errorf("error extracting ACI: %v", err)
 	}
 


### PR DESCRIPTION
Last commit is the interesting one. 

The previous required commit was proposed in #347.
If this or #348 is merged the other one will need a rebase due to added arguments to ExtractTar.