### PR TITLE
cas: add an ACIInfo store to save ImageManifest, related ImageID, latest flag, and import time of every ACI in the store.

### DIFF
--- a/cas/aciinfo.go
+++ b/cas/aciinfo.go
@@ -1,0 +1,47 @@
+package cas
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/appc/spec/schema"
+)
+
+// ACIInfo is used to store informations about an ACI
+// Im is the ACI's image manifest. This avoids extracting it from the ACI every
+// time it's needed
+// BlobKey is the key in the blob store of the related ACI file.
+// Time is the time this ACI was imported in the store
+// Latest defines if the ACI was imported using the latest pattern (no version
+// label provided on ACI discovery)
+type ACIInfo struct {
+	Im      *schema.ImageManifest
+	BlobKey string
+	Time    time.Time
+	Latest  bool
+}
+
+func NewACIInfo(im *schema.ImageManifest, blobKey string, latest bool, t time.Time) *ACIInfo {
+	return &ACIInfo{
+		Im:      im,
+		BlobKey: blobKey,
+		Latest:  latest,
+		Time:    t,
+	}
+}
+
+func (a ACIInfo) Marshal() ([]byte, error) {
+	return json.Marshal(a)
+}
+
+func (a *ACIInfo) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, a)
+}
+
+func (a ACIInfo) Hash() string {
+	return a.BlobKey
+}
+
+func (a ACIInfo) Type() int64 {
+	return aciInfoType
+}

--- a/cas/cas.go
+++ b/cas/cas.go
@@ -36,6 +36,7 @@ import (
 const (
 	blobType int64 = iota
 	remoteType
+	aciInfoType
 
 	defaultPathPerm os.FileMode = 0777
 
@@ -47,10 +48,13 @@ const (
 	lenKey     = len(hashPrefix) + lenHashKey
 )
 
-var otmap = [...]string{
-	"blob",
-	"remote", // remote is a temporary secondary index
-}
+var (
+	otmap = []string{
+		"blob",
+		"remote", // remote is a temporary secondary index
+		"aciinfo",
+	}
+)
 
 // Store encapsulates a content-addressable-storage for storing ACIs on disk.
 type Store struct {

--- a/cas/cas.go
+++ b/cas/cas.go
@@ -169,13 +169,18 @@ func (ds Store) WriteACI(r io.Reader) (string, error) {
 
 type Index interface {
 	Hash() string
-	Marshal() []byte
-	Unmarshal([]byte)
+	Marshal() ([]byte, error)
+	Unmarshal([]byte) error
 	Type() int64
 }
 
-func (ds Store) WriteIndex(i Index) {
-	ds.stores[i.Type()].Write(i.Hash(), i.Marshal())
+func (ds Store) WriteIndex(i Index) error {
+	m, err := i.Marshal()
+	if err != nil {
+		return err
+	}
+	ds.stores[i.Type()].Write(i.Hash(), m)
+	return nil
 }
 
 func (ds Store) ReadIndex(i Index) error {
@@ -184,7 +189,9 @@ func (ds Store) ReadIndex(i Index) error {
 		return err
 	}
 
-	i.Unmarshal(buf)
+	if err = i.Unmarshal(buf); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -76,7 +76,11 @@ func TestDownloading(t *testing.T) {
 		if tt.hit == true && err != nil {
 			panic("expected a hit got a miss")
 		}
-		ds.stores[remoteType].Write(tt.r.Hash(), tt.r.Marshal())
+		rj, err := tt.r.Marshal()
+		if err != nil {
+			panic(err)
+		}
+		ds.stores[remoteType].Write(tt.r.Hash(), rj)
 		_, aciFile, err := tt.r.Download(*ds, nil)
 		if err != nil {
 			t.Fatalf("error downloading aci: %v", err)

--- a/cas/remote.go
+++ b/cas/remote.go
@@ -47,16 +47,12 @@ type Remote struct {
 	BlobKey string
 }
 
-func (r Remote) Marshal() []byte {
-	m, _ := json.Marshal(r)
-	return m
+func (r Remote) Marshal() ([]byte, error) {
+	return json.Marshal(r)
 }
 
-func (r *Remote) Unmarshal(data []byte) {
-	err := json.Unmarshal(data, r)
-	if err != nil {
-		panic(err)
-	}
+func (r *Remote) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, r)
 }
 
 func (r Remote) Hash() string {


### PR DESCRIPTION
This is patch adds an ACIInfo store using diskv . This is a temporary implementation, as from discussion in #71, in future a db will be used to store these infos.

The meaning of latest is explained in appc/spec#73