### PR TITLE
cas: add AppIndex to easily retrieve all ImageManifests ordered by app name.

### DIFF
--- a/cas/appindex.go
+++ b/cas/appindex.go
@@ -1,0 +1,41 @@
+package cas
+
+import (
+	"encoding/json"
+
+	"github.com/appc/spec/schema"
+)
+
+// AppIndex is needed to retrieve all acis matching an app name.
+// ACIInfoKey is the key of the related entry in the ACIInfo index.
+type AppIndex struct {
+	ACIInfoKey string
+	im         *schema.ImageManifest
+}
+
+func NewAppIndex(im *schema.ImageManifest, aciInfoKey string) *AppIndex {
+	a := &AppIndex{
+		im:         im,
+		ACIInfoKey: aciInfoKey,
+	}
+	return a
+}
+
+func (a AppIndex) Marshal() ([]byte, error) {
+	return json.Marshal(a)
+}
+
+func (a *AppIndex) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, a)
+}
+
+// TODO Also this should probably be implemented with a db.
+// The key is a composition of the name hash + "-" + ACIInfoKey
+// In this way we can retrieve from the store all the aci with the same name
+func (a AppIndex) Hash() string {
+	return ShortSHA512(a.im.Name.String()) + "-" + a.ACIInfoKey
+}
+
+func (a AppIndex) Type() int64 {
+	return appIndexType
+}

--- a/cas/cas.go
+++ b/cas/cas.go
@@ -169,13 +169,18 @@ func (ds Store) WriteACI(r io.Reader) (string, error) {
 
 type Index interface {
 	Hash() string
-	Marshal() []byte
-	Unmarshal([]byte)
+	Marshal() ([]byte, error)
+	Unmarshal([]byte) error
 	Type() int64
 }
 
-func (ds Store) WriteIndex(i Index) {
-	ds.stores[i.Type()].Write(i.Hash(), i.Marshal())
+func (ds Store) WriteIndex(i Index) error {
+	m, err := i.Marshal()
+	if err != nil {
+		return err
+	}
+	ds.stores[i.Type()].Write(i.Hash(), m)
+	return nil
 }
 
 func (ds Store) ReadIndex(i Index) error {
@@ -184,7 +189,9 @@ func (ds Store) ReadIndex(i Index) error {
 		return err
 	}
 
-	i.Unmarshal(buf)
+	if err = i.Unmarshal(buf); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -76,7 +76,11 @@ func TestDownloading(t *testing.T) {
 		if tt.hit == true && err != nil {
 			panic("expected a hit got a miss")
 		}
-		ds.stores[remoteType].Write(tt.r.Hash(), tt.r.Marshal())
+		rj, err := tt.r.Marshal()
+		if err != nil {
+			panic(err)
+		}
+		ds.stores[remoteType].Write(tt.r.Hash(), rj)
 		_, aciFile, err := tt.r.Download(*ds, nil)
 		if err != nil {
 			t.Fatalf("error downloading aci: %v", err)

--- a/cas/remote.go
+++ b/cas/remote.go
@@ -47,16 +47,12 @@ type Remote struct {
 	BlobKey string
 }
 
-func (r Remote) Marshal() []byte {
-	m, _ := json.Marshal(r)
-	return m
+func (r Remote) Marshal() ([]byte, error) {
+	return json.Marshal(r)
 }
 
-func (r *Remote) Unmarshal(data []byte) {
-	err := json.Unmarshal(data, r)
-	if err != nil {
-		panic(err)
-	}
+func (r *Remote) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, r)
 }
 
 func (r Remote) Hash() string {

--- a/cas/utils.go
+++ b/cas/utils.go
@@ -17,6 +17,7 @@ package cas
 import (
 	"compress/bzip2"
 	"compress/gzip"
+	"crypto/sha512"
 	"errors"
 	"fmt"
 	"io"
@@ -71,4 +72,9 @@ func decompress(rs io.Reader, typ aci.FileType) (io.Reader, error) {
 		return nil, errors.New("no type returned from DetectFileType?")
 	}
 	return dr, nil
+}
+
+func ShortSHA512(s string) string {
+	sum := sha512.Sum512([]byte(s))
+	return fmt.Sprintf("%s%x", hashPrefix, sum)[0:lenKey]
 }


### PR DESCRIPTION
This is patch adds an ACIInfo store using diskv . This is a temporary (and quite ugly) implementation as its the unique way I found, using diskv to create an index to search by app name without ranging over all the ACIInfos. As from discussion in #71, in future a db will be used to store these infos and everything will be really better.

