### PR TITLE
cas: add a GetACI function.

### DIFF
--- a/cas/aciinfo.go
+++ b/cas/aciinfo.go
@@ -1,0 +1,47 @@
+package cas
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/appc/spec/schema"
+)
+
+// ACIInfo is used to store informations about an ACI
+// Im is the ACI's image manifest. This avoids extracting it from the ACI every
+// time it's needed
+// BlobKey is the key in the blob store of the related ACI file.
+// Time is the time this ACI was imported in the store
+// Latest defines if the ACI was imported using the latest pattern (no version
+// label provided on ACI discovery)
+type ACIInfo struct {
+	Im      *schema.ImageManifest
+	BlobKey string
+	Time    time.Time
+	Latest  bool
+}
+
+func NewACIInfo(im *schema.ImageManifest, blobKey string, latest bool, t time.Time) *ACIInfo {
+	return &ACIInfo{
+		Im:      im,
+		BlobKey: blobKey,
+		Latest:  latest,
+		Time:    t,
+	}
+}
+
+func (a ACIInfo) Marshal() ([]byte, error) {
+	return json.Marshal(a)
+}
+
+func (a *ACIInfo) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, a)
+}
+
+func (a ACIInfo) Hash() string {
+	return a.BlobKey
+}
+
+func (a ACIInfo) Type() int64 {
+	return aciInfoType
+}

--- a/cas/appindex.go
+++ b/cas/appindex.go
@@ -1,0 +1,41 @@
+package cas
+
+import (
+	"encoding/json"
+
+	"github.com/appc/spec/schema"
+)
+
+// AppIndex is needed to retrieve all acis matching an app name.
+// ACIInfoKey is the key of the related entry in the ACIInfo index.
+type AppIndex struct {
+	ACIInfoKey string
+	im         *schema.ImageManifest
+}
+
+func NewAppIndex(im *schema.ImageManifest, aciInfoKey string) *AppIndex {
+	a := &AppIndex{
+		im:         im,
+		ACIInfoKey: aciInfoKey,
+	}
+	return a
+}
+
+func (a AppIndex) Marshal() ([]byte, error) {
+	return json.Marshal(a)
+}
+
+func (a *AppIndex) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, a)
+}
+
+// TODO Also this should probably be implemented with a db.
+// The key is a composition of the name hash + "-" + ACIInfoKey
+// In this way we can retrieve from the store all the aci with the same name
+func (a AppIndex) Hash() string {
+	return ShortSHA512(a.im.Name.String()) + "-" + a.ACIInfoKey
+}
+
+func (a AppIndex) Type() int64 {
+	return appIndexType
+}

--- a/cas/cas.go
+++ b/cas/cas.go
@@ -36,6 +36,7 @@ import (
 const (
 	blobType int64 = iota
 	remoteType
+	aciInfoType
 
 	defaultPathPerm os.FileMode = 0777
 
@@ -47,10 +48,13 @@ const (
 	lenKey     = len(hashPrefix) + lenHashKey
 )
 
-var otmap = [...]string{
-	"blob",
-	"remote", // remote is a temporary secondary index
-}
+var (
+	otmap = []string{
+		"blob",
+		"remote", // remote is a temporary secondary index
+		"aciinfo",
+	}
+)
 
 // Store encapsulates a content-addressable-storage for storing ACIs on disk.
 type Store struct {

--- a/cas/cas.go
+++ b/cas/cas.go
@@ -169,13 +169,18 @@ func (ds Store) WriteACI(r io.Reader) (string, error) {
 
 type Index interface {
 	Hash() string
-	Marshal() []byte
-	Unmarshal([]byte)
+	Marshal() ([]byte, error)
+	Unmarshal([]byte) error
 	Type() int64
 }
 
-func (ds Store) WriteIndex(i Index) {
-	ds.stores[i.Type()].Write(i.Hash(), i.Marshal())
+func (ds Store) WriteIndex(i Index) error {
+	m, err := i.Marshal()
+	if err != nil {
+		return err
+	}
+	ds.stores[i.Type()].Write(i.Hash(), m)
+	return nil
 }
 
 func (ds Store) ReadIndex(i Index) error {
@@ -184,7 +189,9 @@ func (ds Store) ReadIndex(i Index) error {
 		return err
 	}
 
-	i.Unmarshal(buf)
+	if err = i.Unmarshal(buf); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -120,7 +120,7 @@ func TestDownloading(t *testing.T) {
 		}
 		defer os.Remove(aciFile.Name())
 
-		_, err = tt.r.Store(*ds, aciFile)
+		_, err = tt.r.Store(*ds, aciFile, false)
 		if err != nil {
 			panic(err)
 		}

--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -109,7 +109,11 @@ func TestDownloading(t *testing.T) {
 		if tt.hit == true && err != nil {
 			panic("expected a hit got a miss")
 		}
-		ds.stores[remoteType].Write(tt.r.Hash(), tt.r.Marshal())
+		rj, err := tt.r.Marshal()
+		if err != nil {
+			panic(err)
+		}
+		ds.stores[remoteType].Write(tt.r.Hash(), rj)
 		_, aciFile, err := tt.r.Download(*ds, nil)
 		if err != nil {
 			t.Fatalf("error downloading aci: %v", err)

--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -15,8 +15,9 @@
 package cas
 
 import (
+	"archive/tar"
 	"bytes"
-	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/appc/spec/schema/types"
+	"github.com/coreos/rocket/pkg/util"
 )
 
 const tstprefix = "cas-test"
@@ -50,8 +52,38 @@ func TestDownloading(t *testing.T) {
 		t.Fatalf("error creating tempdir: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	// TODO(philips): construct a real tarball using go, this is a base64 tarball with an empty file
-	body, _ := base64.StdEncoding.DecodeString("H4sIAIWbdlQAA+3PPQrCQBiE4ZU0NnoDcTstv8T9OYaNF7AwGFAIJlqn9wba5Cp6EG9gbWtiII1oF0R4n2bYZVhm81WWq46JiDNG1+mdfaVEzblhrQ4jM7M2tE5ESxhZb5SWrofV9lm+3FVT0nWySdLsY6+qxfGXd5qf6Db/xPjYV8X5sFDB/dIbVBfX8jHfDn3ZNgofnG6jiZr+bCMAAAAAAAAAAAAAAAAA4N0T/slETwAoAAA=")
+
+	imj := `{
+			"acKind": "ImageManifest",
+			"acVersion": "0.1.1",
+			"name": "example.com/test01"
+		}`
+
+	entries := []*util.ACIEntry{
+		// An empty file
+		{
+			Contents: "hello",
+			Header: &tar.Header{
+				Name: "rootfs/file01.txt",
+				Size: 5,
+			},
+		},
+	}
+
+	aci, err := util.NewACI(dir, imj, entries)
+	if err != nil {
+		t.Fatalf("error creating test tar: %v", err)
+	}
+
+	// Rewind the ACI
+	if _, err := aci.Seek(0, 0); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	body, err := ioutil.ReadAll(aci)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fmt.Printf("body: %s\n", body)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(body)
 	}))
@@ -62,8 +94,9 @@ func TestDownloading(t *testing.T) {
 		body []byte
 		hit  bool
 	}{
-		{Remote{ts.URL, "", "12", "96609004016e9625763c7153b74120c309c8cb1bd794345bf6fa2e60ac001cd7"}, body, false},
-		{Remote{ts.URL, "", "12", "96609004016e9625763c7153b74120c309c8cb1bd794345bf6fa2e60ac001cd7"}, body, true},
+		// The Blob entry isn't used
+		{Remote{ts.URL, "", "12", ""}, body, false},
+		{Remote{ts.URL, "", "12", ""}, body, true},
 	}
 
 	ds := NewStore(dir)

--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -181,3 +181,146 @@ func TestResolveKey(t *testing.T) {
 		t.Errorf("expected non-nil error!")
 	}
 }
+
+// Test an image with 1 dep. The parent provides a dir not provided by the image.
+func TestGetAci(t *testing.T) {
+	type test struct {
+		name     types.ACName
+		labels   types.Labels
+		expected int // the aci index to expect or -1 if not result expected,
+	}
+
+	type acidef struct {
+		imj    string
+		latest bool
+	}
+
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds := NewStore(dir)
+
+	tests := []struct {
+		acidefs []acidef
+		tests   []test
+	}{
+		{
+			[]acidef{
+				{
+					`{
+						"acKind": "ImageManifest",
+						"acVersion": "0.1.1",
+						"name": "example.com/test01"
+					}`,
+					false,
+				},
+				{
+					`{
+						"acKind": "ImageManifest",
+						"acVersion": "0.1.1",
+						"name": "example.com/test02",
+						"labels": [
+							{
+								"name": "version",
+								"value": "1.0.0"
+							}
+						]
+					}`,
+					true,
+				},
+				{
+					`{
+						"acKind": "ImageManifest",
+						"acVersion": "0.1.1",
+						"name": "example.com/test02",
+						"labels": [
+							{
+								"name": "version",
+								"value": "2.0.0"
+							}
+						]
+					}`,
+					false,
+				},
+			},
+			[]test{
+				{
+					"example.com/unexistentaci",
+					types.Labels{},
+					-1,
+				},
+				{
+					"example.com/test01",
+					types.Labels{},
+					0,
+				},
+				{
+					"example.com/test02",
+					types.Labels{
+						{
+							Name:  "version",
+							Value: "1.0.0",
+						},
+					},
+					1,
+				},
+				{
+					"example.com/test02",
+					types.Labels{
+						{
+							Name:  "version",
+							Value: "2.0.0",
+						},
+					},
+					2,
+				},
+				{
+					"example.com/test02",
+					types.Labels{},
+					1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		keys := []string{}
+		// Create ACIs
+		for _, ad := range tt.acidefs {
+			aci, err := util.NewACI(dir, ad.imj, nil)
+			if err != nil {
+				t.Fatalf("error creating test tar: %v", err)
+			}
+
+			// Rewind the ACI
+			if _, err := aci.Seek(0, 0); err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			key, err := ds.WriteACI(aci, ad.latest)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			keys = append(keys, key)
+		}
+
+		for _, test := range tt.tests {
+			key, err := ds.GetACI(test.name, test.labels)
+			if test.expected == -1 {
+				if err == nil {
+					t.Fatalf("Expected no key, got %s", key)
+				}
+
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error on GetACI for name %s, labels: %v: %v", test.name, test.labels, err)
+				}
+				if keys[test.expected] != key {
+					t.Errorf("expected key: %s, got %s. GetACI with name: %s, labels: %v", key, keys[test.expected], test.name, test.labels)
+				}
+			}
+		}
+	}
+}

--- a/cas/remote.go
+++ b/cas/remote.go
@@ -47,16 +47,12 @@ type Remote struct {
 	BlobKey string
 }
 
-func (r Remote) Marshal() []byte {
-	m, _ := json.Marshal(r)
-	return m
+func (r Remote) Marshal() ([]byte, error) {
+	return json.Marshal(r)
 }
 
-func (r *Remote) Unmarshal(data []byte) {
-	err := json.Unmarshal(data, r)
-	if err != nil {
-		panic(err)
-	}
+func (r *Remote) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, r)
 }
 
 func (r Remote) Hash() string {

--- a/cas/remote.go
+++ b/cas/remote.go
@@ -107,8 +107,8 @@ func (r Remote) Download(ds Store, ks *keystore.Keystore) (*openpgp.Entity, *os.
 
 // TODO: add locking
 // Store stores the ACI represented by r in the target data store.
-func (r Remote) Store(ds Store, aci io.Reader) (*Remote, error) {
-	key, err := ds.WriteACI(aci)
+func (r Remote) Store(ds Store, aci io.Reader, latest bool) (*Remote, error) {
+	key, err := ds.WriteACI(aci, latest)
 	if err != nil {
 		return nil, err
 	}

--- a/cas/utils.go
+++ b/cas/utils.go
@@ -17,6 +17,7 @@ package cas
 import (
 	"compress/bzip2"
 	"compress/gzip"
+	"crypto/sha512"
 	"errors"
 	"fmt"
 	"io"
@@ -71,4 +72,9 @@ func decompress(rs io.Reader, typ aci.FileType) (io.Reader, error) {
 		return nil, errors.New("no type returned from DetectFileType?")
 	}
 	return dr, nil
+}
+
+func ShortSHA512(s string) string {
+	sum := sha512.Sum512([]byte(s))
+	return fmt.Sprintf("%s%x", hashPrefix, sum)[0:lenKey]
 }

--- a/pkg/util/aci.go
+++ b/pkg/util/aci.go
@@ -8,21 +8,33 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/appc/spec/aci"
 	"github.com/appc/spec/schema"
 	"github.com/coreos/rocket/Godeps/_workspace/src/golang.org/x/crypto/openpgp"
 )
 
-// NewACI creates a new ACI with the given name.
+type ACIEntry struct {
+	Header   *tar.Header
+	Contents string
+}
+
+// NewBasicACI creates a new ACI in the given directory with the given name.
 // Used for testing.
-func NewACI(name string) (*os.File, error) {
-	tf, err := ioutil.TempFile("", "")
+func NewBasicACI(dir string, name string) (*os.File, error) {
+	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.1.1","name":"%s"}`, name)
+	return NewACI(dir, manifest, nil)
+}
+
+// NewACI creates a new ACI in the given directory with the given image
+// manifest and entries.
+// Used for testing.
+func NewACI(dir string, manifest string, entries []*ACIEntry) (*os.File, error) {
+	tf, err := ioutil.TempFile(dir, "")
 	if err != nil {
 		return nil, err
 	}
-
-	manifest := fmt.Sprintf(`{"acKind":"ImageManifest","acVersion":"0.1.1","name":"%s"}`, name)
 
 	var im schema.ImageManifest
 	if err := im.UnmarshalJSON([]byte(manifest)); err != nil {
@@ -31,6 +43,22 @@ func NewACI(name string) (*os.File, error) {
 
 	tw := tar.NewWriter(tf)
 	aw := aci.NewImageWriter(im, tw)
+
+	for _, entry := range entries {
+		// Add default mode
+		if entry.Header.Mode == 0 {
+			if entry.Header.Typeflag == tar.TypeDir {
+				entry.Header.Mode = 0755
+			} else {
+				entry.Header.Mode = 0644
+			}
+		}
+		sr := strings.NewReader(entry.Contents)
+		if err := aw.AddFile("", entry.Header, sr); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := aw.Close(); err != nil {
 		return nil, err
 	}

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -118,7 +118,8 @@ func TestFetchImage(t *testing.T) {
 	if _, err := ks.StoreTrustedKeyPrefix("example.com/app", bytes.NewBufferString(key.ArmoredPublicKey)); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	aci, err := util.NewACI("example.com/app")
+	aci, err := util.NewBasicACI(dir, "example.com/app")
+	defer aci.Close()
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -76,7 +76,7 @@ func findImages(args []string, ds *cas.Store, ks *keystore.Keystore) (out []type
 		// import the local file if it exists
 		file, err := os.Open(img)
 		if err == nil {
-			key, err := ds.WriteACI(file)
+			key, err := ds.WriteACI(file, false)
 			file.Close()
 			if err != nil {
 				return nil, fmt.Errorf("%s: %v", img, err)


### PR DESCRIPTION
Last commit is the interesting one.

The previous required commits were proposed in other PRs ( #342 #347 #350 #351 #352 #353 #354)

GetACI returns the best ACI that matches the required app name and the provided
labels.
If there are multiple matching ACIs choose the latest one (defined as the
last one imported in the store).
If no version label is requested, ACIs marked as latest in the ACIInfo are
preferred.