### PR TITLE
stage1/diagexec: use execvp() to facilitate `rkt enter`

### DIFF
--- a/stage1/rootfs/diagexec/diagexec.c
+++ b/stage1/rootfs/diagexec/diagexec.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
 	exe = argv[2];
 	pexit_if(chroot(root) == -1, "Chroot failed");
 	pexit_if(chdir("/") == -1, "Chdir failed");
-	pexit_if(execv(exe, &argv[2]) == -1 &&
+	pexit_if(execvp(exe, &argv[2]) == -1 &&
 		 errno != ENOENT && errno != EACCES,
 		 "Exec of \"%s\" failed", exe);
 	diag(exe);


### PR DESCRIPTION
In `rkt enter` usage, users are likely to specify a filename rather than a
path expecting $PATH lookup resolution to occur.