### PR TITLE
pkg/lock: add DirLock.Unlock()

### DIFF
--- a/pkg/lock/dir.go
+++ b/pkg/lock/dir.go
@@ -126,6 +126,11 @@ func SharedLock(dir string) (*DirLock, error) {
 	return l, nil
 }
 
+// Unlock unlocks the lock
+func (l *DirLock) Unlock() error {
+	return syscall.Flock(l.fd, syscall.LOCK_UN)
+}
+
 // Fd returns the lock's file descriptor
 func (l *DirLock) Fd() (int, error) {
 	var err error

--- a/pkg/lock/dir_test.go
+++ b/pkg/lock/dir_test.go
@@ -140,9 +140,11 @@ func TestSharedLock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error closing lock: %v", err)
 	}
-	err = l3.Close()
+
+	// Only unlock one of them
+	err = l3.Unlock()
 	if err != nil {
-		t.Fatalf("error closing lock: %v", err)
+		t.Fatalf("error unlocking lock: %v", err)
 	}
 
 	// Now try an exclusive lock, should succeed


### PR DESCRIPTION
In creating a more general interface to the container dirs a method for
unlocking a DirLock without closing it became necessary.

This should have been added when lock.NewLock() became public.