### PR TITLE
invoke net plugins from stage1 -- disabled for now

### DIFF
--- a/networking/net-plugin.go
+++ b/networking/net-plugin.go
@@ -101,8 +101,6 @@ func (np *NetPlugin) Add(n *Net, contID types.UUID, netns, args, ifName string) 
 			return nil, err
 		}
 
-		fmt.Printf("plugin's output %q\n", output)
-
 		return util.ParseCIDR(output)
 	}
 }

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -204,7 +204,7 @@ func Run(dir string, debug bool) {
 	log.Printf("Execing %s", initPath)
 	args := []string{initPath}
 	if debug {
-		args = append(args, "debug")
+		args = append(args, "--debug")
 	}
 	if err := syscall.Exec(initPath, args, os.Environ()); err != nil {
 		log.Fatalf("error execing init: %v", err)

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -19,12 +19,16 @@ package main
 // this implements /init of stage1/nspawn+systemd
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"syscall"
 
+	"github.com/coreos/rocket/networking"
 	"github.com/coreos/rocket/path"
 )
 
@@ -63,21 +67,34 @@ func mirrorLocalZoneInfo(root string) {
 	_, _ = io.Copy(dest, src)
 }
 
-func main() {
-	root := "."
-	debug := len(os.Args) > 1 && os.Args[1] == "debug"
+var (
+	debug   bool
+	privNet bool
+)
 
+func init() {
+	flag.BoolVar(&debug, "debug", false, "Run in debug mode")
+	flag.BoolVar(&privNet, "private-net", false, "Setup private network (WIP!)")
+
+	// this ensures that main runs only on main thread (thread group leader).
+	// since namespace ops (unshare, setns) are done for a single thread, we
+	// must ensure that the goroutine does not jump from OS thread to thread
+	runtime.LockOSThread()
+}
+
+func stage1() int {
+	root := "."
 	c, err := LoadContainer(root)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to load container: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	mirrorLocalZoneInfo(c.Root)
 
 	if err = c.ContainerToSystemd(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to configure systemd: %v\n", err)
-		os.Exit(2)
+		return 2
 	}
 
 	args := []string{
@@ -94,7 +111,7 @@ func main() {
 	nsargs, err := c.ContainerToNspawnArgs()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to generate nspawn args: %v\n", err)
-		os.Exit(4)
+		return 4
 	}
 	args = append(args, nsargs...)
 
@@ -110,8 +127,41 @@ func main() {
 	env = append(env, "LD_PRELOAD="+filepath.Join(path.Stage1RootfsPath(c.Root), "fakesdboot.so"))
 	env = append(env, "LD_LIBRARY_PATH="+filepath.Join(path.Stage1RootfsPath(c.Root), "usr/lib"))
 
-	if err := syscall.Exec(args[0], args, env); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to execute nspawn: %v\n", err)
-		os.Exit(5)
+	if privNet {
+		n, err := networking.Setup(c.Manifest.UUID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to setup network: %v\n", err)
+			return 6
+		}
+		defer n.Teardown()
+
+		if err = n.EnterContNS(); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to switch to container netns: %v\n", err)
+			return 6
+		}
+
+		cmd := exec.Cmd{
+			Args:   args,
+			Stdin:  os.Stdin,
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+			Env:    env,
+		}
+		err = cmd.Run()
+	} else {
+		err = syscall.Exec(args[0], args, env)
 	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to execute nspawn: %v\n", err)
+		return 5
+	}
+
+	return 0
+}
+
+func main() {
+	flag.Parse()
+	// move code into stage1() helper so defered fns get run
+	os.Exit(stage1())
 }


### PR DESCRIPTION
Invoke the private networking from stage1. It's currently disabled -- the flag defaults to false and it's not plumbed through to stage0.