### PR TITLE
cas: remote: clarify the meaning of Blob and rename it to BlobKey.

### DIFF
--- a/cas/remote.go
+++ b/cas/remote.go
@@ -43,7 +43,8 @@ type Remote struct {
 	ACIURL string
 	SigURL string
 	ETag   string
-	Blob   string
+	// The key in the blob store under which the ACI has been saved.
+	BlobKey string
 }
 
 func (r Remote) Marshal() []byte {
@@ -115,7 +116,7 @@ func (r Remote) Store(ds Store, aci io.Reader) (*Remote, error) {
 	if err != nil {
 		return nil, err
 	}
-	r.Blob = key
+	r.BlobKey = key
 	ds.WriteIndex(&r)
 	return &r, nil
 }

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -107,7 +107,7 @@ func downloadImage(rem *cas.Remote, ds *cas.Store, ks *keystore.Keystore) (strin
 		fmt.Printf("rkt: warning: signature verification has been disabled\n")
 	}
 	err := ds.ReadIndex(rem)
-	if err != nil && rem.Blob == "" {
+	if err != nil && rem.BlobKey == "" {
 		entity, aciFile, err := rem.Download(*ds, ks)
 		if err != nil {
 			return "", err
@@ -125,7 +125,7 @@ func downloadImage(rem *cas.Remote, ds *cas.Store, ks *keystore.Keystore) (strin
 			return "", err
 		}
 	}
-	return rem.Blob, nil
+	return rem.BlobKey, nil
 }
 
 func validateURL(s string) error {


### PR DESCRIPTION
as Remote.Blob is used to store the related key on the diskv blob store rename it to BlobKey.

It should also be noted that it's not the same as an ImageID (as an ImageID can
be a sha512 with different key lenghts) and to deriver a
BlobKey from an imageID one should use cas.ResolveKey(ImageID).

In the last update round of the various acirenderer patches (for example #297, #356 etc...)
I decoupled key from ImageID and always use key in the various cas functions, and, when I 
have a types.Hash imageID, I first call cas.ResolveKey(ImageID) to get the key.