### PR TITLE
fetch: do not build keystore if InsecureSkipVerify

### DIFF
--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -53,8 +53,7 @@ func runFetch(args []string) (exit int) {
 	}
 
 	ds := cas.NewStore(globalFlags.Dir)
-	ks := keystore.New(nil)
-
+	ks := getKeystore()
 	for _, img := range args {
 		hash, err := fetchImage(img, ds, ks)
 		if err != nil {

--- a/rkt/rkt.go
+++ b/rkt/rkt.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"path/filepath"
 	"text/tabwriter"
+
+	"github.com/coreos/rocket/pkg/keystore"
 )
 
 const (
@@ -112,4 +114,11 @@ func containersDir() string {
 
 func garbageDir() string {
 	return filepath.Join(globalFlags.Dir, "garbage")
+}
+
+func getKeystore() *keystore.Keystore {
+	if globalFlags.InsecureSkipVerify {
+		return nil
+	}
+	return keystore.New(nil)
 }

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -121,7 +121,7 @@ func runRun(args []string) (exit int) {
 	}
 
 	ds := cas.NewStore(globalFlags.Dir)
-	ks := keystore.New(nil)
+	ks := getKeystore()
 	imgs, err := findImages(args, ds, ks)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)


### PR DESCRIPTION
The cas decides whether to retrieve the signature based on whether the 
supplied *keystore.Keystore is non-nil; however, we were not properly passing
a nil Keystore through in the case that InsecureSkipVerify is set, so it was
still attempting to retrieve a signature in this case.

/cc @kelseyhightower