### PR TITLE
stage1: use newUnitOption for WorkingDirectory.

### DIFF
--- a/stage1/init/container.go
+++ b/stage1/init/container.go
@@ -147,7 +147,7 @@ func (c *Container) appToSystemd(am *schema.ImageManifest, id types.Hash) error 
 	}
 
 	if app.WorkingDirectory != "" {
-		opts = append(opts, &unit.UnitOption{"Service", "WorkingDirectory", app.WorkingDirectory})
+		opts = append(opts, newUnitOption("Service", "WorkingDirectory", app.WorkingDirectory))
 	}
 
 	saPorts := []types.Port{}


### PR DESCRIPTION
commit dbcdb4a8 used unit.UnitOption composite literals causing go vet
complaining (at least on my system, dunno why tests on travis are working).
This was fixed in other places by 1af30a2d but dbcdb4a8 was older.