### PR TITLE
cas: Add Imagemanifeststore, save ImageManifest on WriteACI and ad GetImageManifest function.

### DIFF
--- a/cas/cas.go
+++ b/cas/cas.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/aci"
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema"
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/peterbourgon/diskv"
 )
@@ -245,6 +246,19 @@ func (ds Store) WriteRemote(remote *Remote) error {
 		return WriteRemote(tx, remote)
 	})
 	return err
+}
+
+// Get the ImageManifest with the specified key.
+func (ds Store) GetImageManifest(key string) (*schema.ImageManifest, error) {
+	imj, err := ds.stores[imageManifestType].Read(key)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving image manifest: %v", err)
+	}
+	var im *schema.ImageManifest
+	if err = json.Unmarshal(imj, &im); err != nil {
+		return nil, fmt.Errorf("error unmarshalling image manifest: %v", err)
+	}
+	return im, nil
 }
 
 func (ds Store) Dump(hex bool) {


### PR DESCRIPTION
Last two commits are the interesting ones.

The previous required commits were proposed in other #342 (only needed for tests)

Add a new diskv store to save the ImageManifest of an ACI. As future functions
will need the image manifest this avoids the needs (and slowness) of extracting
it from the ACI.
As an ACI and its image manifest are tied together, on WriteACI the image
manifest is saved using the same key of the blob store.

GetImageManifest retrieves the ImageManifest with the specified key.
