### PR TITLE
cas: add an ACIInfo table

### DIFF
--- a/cas/aciinfo.go
+++ b/cas/aciinfo.go
@@ -1,0 +1,67 @@
+package cas
+
+import (
+	"database/sql"
+	"time"
+)
+
+// ACIInfo is used to store information about an ACI.
+type ACIInfo struct {
+	// BlobKey is the key in the blob/imageManifest store of the related
+	// ACI file and is the db primary key.
+	BlobKey string
+	// AppName is the app name provided by the ACI.
+	AppName string
+	// ImportTime is the time this ACI was imported in the store.
+	ImportTime time.Time
+	// Latest defines if the ACI was imported using the latest pattern (no
+	// version label was provided on ACI discovery)
+	Latest bool
+}
+
+func NewACIInfo(blobKey string, latest bool, t time.Time) *ACIInfo {
+	return &ACIInfo{
+		BlobKey:    blobKey,
+		Latest:     latest,
+		ImportTime: t,
+	}
+}
+
+// GetAciInfosWithAppName returns all the ACIInfos for a given appname. found will be
+// false if no aciinfo exists.
+func GetACIInfosWithAppName(tx *sql.Tx, appname string) ([]*ACIInfo, bool, error) {
+	aciinfos := []*ACIInfo{}
+	found := false
+	rows, err := tx.Query("SELECT * from aciinfo WHERE appname == $1", appname)
+	if err != nil {
+		return nil, false, err
+	}
+	for rows.Next() {
+		found = true
+		aciinfo := &ACIInfo{}
+		if err := rows.Scan(&aciinfo.BlobKey, &aciinfo.AppName, &aciinfo.ImportTime, &aciinfo.Latest); err != nil {
+			return nil, false, err
+		}
+		aciinfos = append(aciinfos, aciinfo)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	return aciinfos, found, err
+}
+
+// WriteACIInfo adds or updates the provided aciinfo.
+func WriteACIInfo(tx *sql.Tx, aciinfo *ACIInfo) error {
+	// ql doesn't have an INSERT OR UPDATE function so
+	// it's faster to remove and reinsert the row
+	_, err := tx.Exec("DELETE from aciinfo where blobkey == $1", aciinfo.BlobKey)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec("INSERT into aciinfo values ($1, $2, $3, $4)", aciinfo.BlobKey, aciinfo.AppName, aciinfo.ImportTime, aciinfo.Latest)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cas/aciinfo_test.go
+++ b/cas/aciinfo_test.go
@@ -1,0 +1,79 @@
+package cas
+
+import (
+	"database/sql"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestWriteACIInfo(t *testing.T) {
+	dir, err := ioutil.TempDir("", tstprefix)
+	if err != nil {
+		t.Fatalf("error creating tempdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	ds, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if err = ds.db.Do(func(tx *sql.Tx) error {
+		aciinfo := &ACIInfo{
+			BlobKey: "key01",
+			AppName: "name01",
+		}
+		if err := WriteACIInfo(tx, aciinfo); err != nil {
+			return err
+		}
+		// Insert it another time to check that is should be overwritten
+		if err := WriteACIInfo(tx, aciinfo); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	aciinfos := []*ACIInfo{}
+	ok := false
+	if err = ds.db.Do(func(tx *sql.Tx) error {
+		aciinfos, ok, err = GetACIInfosWithAppName(tx, "name01")
+		return err
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !ok {
+		t.Fatalf("expected some records but none found")
+	}
+	if len(aciinfos) != 1 {
+		t.Fatalf("wrong number of records returned, wanted: 1, got: %d", len(aciinfos))
+	}
+
+	// Add another ACIInfo for the same app name
+	if err = ds.db.Do(func(tx *sql.Tx) error {
+		aciinfo := &ACIInfo{
+			BlobKey: "key02",
+			AppName: "name01",
+		}
+		if err := WriteACIInfo(tx, aciinfo); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err = ds.db.Do(func(tx *sql.Tx) error {
+		aciinfos, ok, err = GetACIInfosWithAppName(tx, "name01")
+		return err
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !ok {
+		t.Fatalf("expected some records but none found")
+	}
+	if len(aciinfos) != 2 {
+		t.Fatalf("wrong number of records returned, wanted: 2, got: %d", len(aciinfos))
+	}
+}

--- a/cas/schema.go
+++ b/cas/schema.go
@@ -16,9 +16,14 @@ var dbCreateStmts = [...]string{
 	"CREATE TABLE IF NOT EXISTS version (version int);",
 	fmt.Sprintf("INSERT INTO version VALUES (%d)", dbVersion),
 
-	// remote Table. The primary key is "aciurl".
+	// remote table. The primary key is "aciurl".
 	"CREATE TABLE IF NOT EXISTS remote (aciurl string, sigurl string, etag string, blobkey string);",
 	"CREATE UNIQUE INDEX IF NOT EXISTS aciurlidx ON remote (aciurl)",
+
+	// aciinfo table. The primary key is "blobkey" and it matches the key used to save that aci in the blob store
+	"CREATE TABLE IF NOT EXISTS aciinfo (blobkey string, appname string, importtime time, latest bool);",
+	"CREATE UNIQUE INDEX IF NOT EXISTS blobkeyidx ON aciinfo (blobkey)",
+	"CREATE INDEX IF NOT EXISTS appnameidx ON aciinfo (appname)",
 }
 
 // dbIsPopulated checks if the db is already populated (at any version) verifing if the "version" table exists


### PR DESCRIPTION
Last commit is the interesting one. It needs the db implementation provided in #361 and is based over #392. IMHO this db based implementation is really cleaner and better that the hackish diskv based ones proposed in #352 and #353.

The ACIInfo table saves informations on the ACIs. The saved informations are:

* BlobKey is the key in the blob and imageManifest store of the related ACI file.
* AppName is the app name provided by the ACI.
* ImportTime is the time this ACI was imported in the store
* Latest defines if the ACI was imported using the latest pattern (no version
label provided on ACI discovery)


About the latest pattern please see (and comment) on appc/spec#73.