### PR TITLE
cas: Introduce latest pattern handling for image fetching.

### DIFF
--- a/cas/cas.go
+++ b/cas/cas.go
@@ -179,7 +179,9 @@ func (ds Store) WriteStream(key string, r io.Reader) error {
 // WriteACI takes an ACI encapsulated in an io.Reader, decompresses it if
 // necessary, and then stores it in the store under a key based on the image ID
 // (i.e. the hash of the uncompressed ACI)
-func (ds Store) WriteACI(r io.Reader) (string, error) {
+// latest defines if the aci has to be marked as the latest. For example an ACI
+// discovered without asking for a specific version (latest pattern).
+func (ds Store) WriteACI(r io.Reader, latest bool) (string, error) {
 	// Peek at the first 512 bytes of the reader to detect filetype
 	br := bufio.NewReaderSize(r, 32768)
 	hd, err := br.Peek(512)
@@ -238,6 +240,7 @@ func (ds Store) WriteACI(r io.Reader) (string, error) {
 			BlobKey:    key,
 			AppName:    im.Name.String(),
 			ImportTime: time.Now(),
+			Latest:     latest,
 		}
 		return WriteACIInfo(tx, aciinfo)
 	}); err != nil {

--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -127,7 +127,7 @@ func TestDownloading(t *testing.T) {
 		}
 		defer os.Remove(aciFile.Name())
 
-		_, err = rem.Store(*ds, aciFile)
+		_, err = rem.Store(*ds, aciFile, false)
 		if err != nil {
 			panic(err)
 		}
@@ -253,7 +253,7 @@ func TestGetImageManifest(t *testing.T) {
 	if _, err := aci.Seek(0, 0); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	key, err := ds.WriteACI(aci)
+	key, err := ds.WriteACI(aci, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cas/remote.go
+++ b/cas/remote.go
@@ -122,8 +122,8 @@ func (r Remote) Download(ds Store, ks *keystore.Keystore) (*openpgp.Entity, *os.
 
 // TODO: add locking
 // Store stores the ACI represented by r in the target data store.
-func (r Remote) Store(ds Store, aci io.Reader) (*Remote, error) {
-	key, err := ds.WriteACI(aci)
+func (r Remote) Store(ds Store, aci io.Reader, latest bool) (*Remote, error) {
+	key, err := ds.WriteACI(aci, latest)
 	if err != nil {
 		return nil, err
 	}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -106,7 +106,7 @@ func findImage(img string, ds *cas.Store, ks *keystore.Keystore, discover bool) 
 	// import the local file if it exists
 	file, err := os.Open(img)
 	if err == nil {
-		key, err := ds.WriteACI(file)
+		key, err := ds.WriteACI(file, false)
 		file.Close()
 		if err != nil {
 			return nil, fmt.Errorf("%s: %v", img, err)


### PR DESCRIPTION
The last commit is the interesting one. It's based on #393.

On fetching, if downloaded with the "latest" pattern (no version label
specified), the ACI is saved in the store with the "latest" flag.

In future, on "rkt fetch" or "rkt run", a way for the user to define if the
provided images (by local file or URL) should be saved in the store with the
lastest flag, should be provided. For doing this there's the need to find how
the user can request this for a specific file/URL as multiple files/URls can be
provided.

See appc/spec#73 for my thoughts about the need of the "latest" flag.