### PR TITLE
cas: add a GetACI function.

### DIFF
--- a/cas/cas.go
+++ b/cas/cas.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/aci"
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/peterbourgon/diskv"
 )
@@ -281,6 +282,76 @@ func (ds Store) GetImageManifest(key string) (*schema.ImageManifest, error) {
 		return nil, fmt.Errorf("error unmarshalling image manifest: %v", err)
 	}
 	return im, nil
+}
+
+// GetACI retrieves the ACI that best matches the provided app name and labels.
+// The returned value is the blob store key of the retrieved ACI.
+// If there are multiple matching ACIs choose the latest one (defined as the
+// last one imported in the store).
+// If no version label is requested, ACIs marked as latest in the ACIInfo are
+// preferred.
+func (ds Store) GetACI(name types.ACName, labels types.Labels) (string, error) {
+	var curaciinfo *ACIInfo
+	versionRequested := false
+	if _, ok := labels.Get("version"); ok {
+		versionRequested = true
+	}
+
+	var aciinfos []*ACIInfo
+	err := ds.db.Do(func(tx *sql.Tx) error {
+		var err error
+		aciinfos, _, err = GetACIInfosWithAppName(tx, name.String())
+		return err
+	})
+	if err != nil {
+		return "", err
+	}
+
+nextKey:
+	for _, aciinfo := range aciinfos {
+		im, err := ds.GetImageManifest(aciinfo.BlobKey)
+		if err != nil {
+			return "", fmt.Errorf("error getting image manifest: %v", err)
+		}
+
+		// The image manifest must have all the requested labels
+		for _, l := range labels {
+			ok := false
+			for _, rl := range im.Labels {
+				if l.Name == rl.Name && l.Value == rl.Value {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				continue nextKey
+			}
+		}
+
+		if curaciinfo != nil {
+			// If no version is requested prefer the acis marked as latest
+			if !versionRequested {
+				if !curaciinfo.Latest && aciinfo.Latest {
+					curaciinfo = aciinfo
+					continue nextKey
+				}
+				if curaciinfo.Latest && !aciinfo.Latest {
+					continue nextKey
+				}
+			}
+			// If multiple matching image manifests are found, choose the latest imported in the cas.
+			if aciinfo.ImportTime.After(curaciinfo.ImportTime) {
+				curaciinfo = aciinfo
+			}
+		} else {
+			curaciinfo = aciinfo
+		}
+	}
+
+	if curaciinfo != nil {
+		return curaciinfo.BlobKey, nil
+	}
+	return "", fmt.Errorf("aci not found")
 }
 
 func (ds Store) Dump(hex bool) {

--- a/cas/cas.go
+++ b/cas/cas.go
@@ -179,7 +179,9 @@ func (ds Store) WriteStream(key string, r io.Reader) error {
 // WriteACI takes an ACI encapsulated in an io.Reader, decompresses it if
 // necessary, and then stores it in the store under a key based on the image ID
 // (i.e. the hash of the uncompressed ACI)
-func (ds Store) WriteACI(r io.Reader) (string, error) {
+// latest defines if the aci has to be marked as the latest. For example an ACI
+// discovered without asking for a specific version (latest pattern).
+func (ds Store) WriteACI(r io.Reader, latest bool) (string, error) {
 	// Peek at the first 512 bytes of the reader to detect filetype
 	br := bufio.NewReaderSize(r, 32768)
 	hd, err := br.Peek(512)
@@ -238,6 +240,7 @@ func (ds Store) WriteACI(r io.Reader) (string, error) {
 			BlobKey:    key,
 			AppName:    im.Name.String(),
 			ImportTime: time.Now(),
+			Latest:     latest,
 		}
 		return WriteACIInfo(tx, aciinfo)
 	}); err != nil {

--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -127,7 +127,7 @@ func TestDownloading(t *testing.T) {
 		}
 		defer os.Remove(aciFile.Name())
 
-		_, err = rem.Store(*ds, aciFile)
+		_, err = rem.Store(*ds, aciFile, false)
 		if err != nil {
 			panic(err)
 		}
@@ -253,7 +253,7 @@ func TestGetImageManifest(t *testing.T) {
 	if _, err := aci.Seek(0, 0); err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	key, err := ds.WriteACI(aci)
+	key, err := ds.WriteACI(aci, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cas/remote.go
+++ b/cas/remote.go
@@ -122,8 +122,8 @@ func (r Remote) Download(ds Store, ks *keystore.Keystore) (*openpgp.Entity, *os.
 
 // TODO: add locking
 // Store stores the ACI represented by r in the target data store.
-func (r Remote) Store(ds Store, aci io.Reader) (*Remote, error) {
-	key, err := ds.WriteACI(aci)
+func (r Remote) Store(ds Store, aci io.Reader, latest bool) (*Remote, error) {
+	key, err := ds.WriteACI(aci, latest)
 	if err != nil {
 		return nil, err
 	}

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -106,7 +106,7 @@ func findImage(img string, ds *cas.Store, ks *keystore.Keystore, discover bool) 
 	// import the local file if it exists
 	file, err := os.Open(img)
 	if err == nil {
-		key, err := ds.WriteACI(file)
+		key, err := ds.WriteACI(file, false)
 		file.Close()
 		if err != nil {
 			return nil, fmt.Errorf("%s: %v", img, err)


### PR DESCRIPTION
The last commit is the interesting one. It's based on #394.

GetACI returns the best ACI that matches the required app name and the provided
labels.
If there are multiple matching ACIs choose the latest one (defined as the
last one imported in the store).
If no version label is requested, ACIs marked as latest in the ACIInfo are
preferred.