### PR TITLE
net: Give the host end of veth an IP

### DIFF
--- a/networking/networking.go
+++ b/networking/networking.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	ifnamePattern = "eth%d"
-	selfNetNS = "/proc/self/ns/net"
+	selfNetNS     = "/proc/self/ns/net"
 )
 
 type activeNet struct {
@@ -141,7 +141,6 @@ func basicNetNS() (hostNS, contNS *os.File, err error) {
 	return
 }
 
-
 func (n *Networking) EnterHostNS() error {
 	return util.SetNS(n.hostNS, syscall.CLONE_NEWNET)
 }
@@ -163,7 +162,7 @@ func setupNets(contID types.UUID, netns string, plugins map[string]*NetPlugin, n
 		}
 
 		an := activeNet{
-			Net: nt,
+			Net:    nt,
 			ifName: fmt.Sprintf(ifnamePattern, i),
 		}
 

--- a/networking/util/net.go
+++ b/networking/util/net.go
@@ -22,13 +22,13 @@ import (
 
 type Net struct {
 	Filename string
-	Name     string   `json:"name,omitempty"`
-	Type     string   `json:"type,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Type     string `json:"type,omitempty"`
 	IPAlloc  struct {
 		Type   string `json:"type,omitempty"`
 		Subnet string `json:"subnet,omitempty"`
-	}                 `json:"ipAlloc,omitempty"`
-	Routes   []string `json:"routes,omitempty"`
+	} `json:"ipAlloc,omitempty"`
+	Routes []string `json:"routes,omitempty"`
 }
 
 func LoadNet(path string, n interface{}) error {

--- a/networking/util/route.go
+++ b/networking/util/route.go
@@ -34,3 +34,11 @@ func AddRoute(ipn *net.IPNet, gw net.IP, dev netlink.Link) error {
 	})
 }
 
+func AddHostRoute(ipn *net.IPNet, gw net.IP, dev netlink.Link) error {
+	return netlink.RouteAdd(&netlink.Route{
+		LinkIndex: dev.Attrs().Index,
+		Scope:     netlink.SCOPE_HOST,
+		Dst:       ipn,
+		Gw:        gw,
+	})
+}

--- a/networking/util/setns.go
+++ b/networking/util/setns.go
@@ -50,12 +50,14 @@ func WithNetNSPath(nspath string, f func(*os.File) error) error {
 	if err != nil {
 		return fmt.Errorf("Failed to open /proc/self/ns/net: %v", err)
 	}
+	defer thisNS.Close()
 
 	// switch to the container namespace
 	ns, err := os.Open(nspath)
 	if err != nil {
 		return fmt.Errorf("Failed to open %v: %v", nspath, err)
 	}
+	defer ns.Close()
 
 	if err = SetNS(ns, syscall.CLONE_NEWNET); err != nil {
 		return fmt.Errorf("Error switching to ns %v: %v", nspath, err)
@@ -66,9 +68,5 @@ func WithNetNSPath(nspath string, f func(*os.File) error) error {
 	}
 
 	// switch back
-	if err = SetNS(thisNS, syscall.CLONE_NEWNET); err != nil {
-		return err
-	}
-
-	return nil
+	return SetNS(thisNS, syscall.CLONE_NEWNET)
 }


### PR DESCRIPTION
The scheme of having a host veth not have an IP
and not be plugged into bridge does not work in
practice. This creates a true point-to-point link
between the container and the host.