### PR TITLE
metadatasvc: remove string "header" from http header match

### DIFF
--- a/metadatasvc/main.go
+++ b/metadatasvc/main.go
@@ -415,7 +415,7 @@ func main() {
 	r.HandleFunc("/containers/", logReq(handleRegisterContainer)).Methods("POST")
 	r.HandleFunc("/containers/{uid}/{app:.*}", logReq(handleRegisterApp)).Methods("PUT")
 
-	acRtr := r.Headers("Metadata-Flavor", "AppContainer header").
+	acRtr := r.Headers("Metadata-Flavor", "AppContainer").
 		PathPrefix("/acMetadata/v1").Subrouter()
 
 	mr := acRtr.Methods("GET").Subrouter()


### PR DESCRIPTION
see  issue https://github.com/coreos/rocket/issues/409

The specification says that queries to the metadata service must have an HTTP header:

Metadata-Flavor: AppContainer

The actual check in the metadatasvc main.go is for "AppContainer header"