### PR TITLE
build: don't fail if GOPATH is unset

### DIFF
--- a/build
+++ b/build
@@ -9,7 +9,7 @@ if [ ! -h gopath/src/${REPO_PATH} ]; then
 fi
 
 export GOBIN=${PWD}/bin
-export GOPATH=${GOPATH}:${PWD}/gopath
+export GOPATH=${GOPATH:-}:${PWD}/gopath
 
 eval $(go env)
 


### PR DESCRIPTION
build should be callable even if the user's env has no GOPATH in it