### PR TITLE
rkt: introduce the volume flag

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -64,10 +64,10 @@ type Config struct {
 	Stage1Rootfs  string     // compressed bundle containing a rootfs for stage1
 	Debug         bool
 	// TODO(jonboulle): These images are partially-populated hashes, this should be clarified.
-	Images           []types.Hash      // application images
-	Volumes          map[string]string // map of volumes that rocket can provide to applications
-	PrivateNet       bool              // container should have its own network stack
-	SpawnMetadataSvc bool              // launch metadata service
+	Images           []types.Hash   // application images
+	Volumes          []types.Volume // map of volumes that rocket can provide to applications
+	PrivateNet       bool           // container should have its own network stack
+	SpawnMetadataSvc bool           // launch metadata service
 }
 
 func init() {
@@ -163,21 +163,9 @@ func Setup(cfg Config) (string, error) {
 		cm.Apps = append(cm.Apps, a)
 	}
 
-	var sVols []types.Volume
-	for key, path := range cfg.Volumes {
-		v := types.Volume{
-			Kind:     "host",
-			Source:   path,
-			ReadOnly: true,
-			Fulfills: []types.ACName{
-				types.ACName(key),
-			},
-		}
-		sVols = append(sVols, v)
-	}
 	// TODO(jonboulle): check that app mountpoint expectations are
 	// satisfied here, rather than waiting for stage1
-	cm.Volumes = sVols
+	cm.Volumes = cfg.Volumes
 
 	cdoc, err := json.Marshal(cm)
 	if err != nil {

--- a/stage1/init/container.go
+++ b/stage1/init/container.go
@@ -242,10 +242,14 @@ func (c *Container) appToNspawnArgs(am *schema.ImageManifest, id types.Hash) ([]
 	name := am.Name.String()
 
 	vols := make(map[types.ACName]types.Volume)
+
+	// TODO(philips): this is implcitly creating a mapping from MountPoint
+	// to volumes. This is a nice convenience for users but we will need to
+	// introduce a --mount flag so they can control which mountPoint map to
+	// which volume.
+
 	for _, v := range c.Manifest.Volumes {
-		for _, f := range v.Fulfills {
-			vols[f] = v
-		}
+		vols[v.Name] = v
 	}
 
 	for _, mp := range am.App.MountPoints {


### PR DESCRIPTION
Introduce a more complete volume format that can specify arguments and details
of the volume to be mounted. For example:

```
rkt run --volume database,kind=host,source=/tmp
```

This will implicitly create a mount points for every app called 'database'. In
a follow-on patch we will introduce a --mount flag that will add a particular
volume to a particular app.

Depends on https://github.com/appc/spec/pull/143