### PR TITLE
cas: print URL when retrieving remote signature

### DIFF
--- a/cas/remote.go
+++ b/cas/remote.go
@@ -80,6 +80,7 @@ func (r Remote) Download(ds Store, ks *keystore.Keystore) (*openpgp.Entity, *os.
 	}
 
 	if ks != nil {
+		fmt.Printf("Downloading signature from %v\n", r.SigURL)
 		sigTempFile, err := downloadSignatureFile(r.SigURL)
 		if err != nil {
 			return nil, acif, fmt.Errorf("error downloading the signature file: %v", err)


### PR DESCRIPTION
This is for symmetry with printing out the ACI URL; in future we can 
standardise this better as we tweak what exactly goes to stdout, but I think
this adds value for now.