### PR TITLE
*: add missing godocs and copyright headers

### DIFF
--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/appc/spec/schema/types"
-	"github.com/coreos/rocket/pkg/util"
+	"github.com/coreos/rocket/pkg/aci"
 )
 
 const tstprefix = "cas-test"
@@ -59,7 +59,7 @@ func TestDownloading(t *testing.T) {
 			"name": "example.com/test01"
 		}`
 
-	entries := []*util.ACIEntry{
+	entries := []*aci.ACIEntry{
 		// An empty file
 		{
 			Contents: "hello",
@@ -70,7 +70,7 @@ func TestDownloading(t *testing.T) {
 		},
 	}
 
-	aci, err := util.NewACI(dir, imj, entries)
+	aci, err := aci.NewACI(dir, imj, entries)
 	if err != nil {
 		t.Fatalf("error creating test tar: %v", err)
 	}

--- a/cas/remote.go
+++ b/cas/remote.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package cas implements a content-addressable-store on disk.
+// It leverages the `diskv` package to store items in a simple
+// key-value blob store: https://github.com/peterbourgon/diskv
 package cas
 
 import (

--- a/cas/remote_test.go
+++ b/cas/remote_test.go
@@ -1,3 +1,17 @@
+// Copyright 2014 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cas
 
 import (

--- a/networking/plugins/bridge/bridge.go
+++ b/networking/plugins/bridge/bridge.go
@@ -1,3 +1,17 @@
+// Copyright 2014 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/pkg/aci/aci.go
+++ b/pkg/aci/aci.go
@@ -1,4 +1,19 @@
-package util
+// Copyright 2014 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package aci implements helper functions for working with ACIs
+package aci
 
 import (
 	"archive/tar"

--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -38,8 +38,8 @@ type Config struct {
 	SystemPrefixPath string
 }
 
-// A Keystore represents a repository of trusted keys which can be used to verify
-// ACI images.
+// A Keystore represents a repository of trusted public keys which can be
+// used to verify PGP signatures.
 type Keystore struct {
 	*Config
 }

--- a/pkg/lock/dir.go
+++ b/pkg/lock/dir.go
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package lock implements simple locking primitives on a
+// directory using flock
 package lock
 
-// Package lock implements simple locking primitives on a directory using flock
 import (
 	"errors"
 	"syscall"
@@ -26,6 +27,7 @@ var (
 	ErrPermission = errors.New("permission denied")
 )
 
+// DirLock represents a lock on a directory
 type DirLock struct {
 	dir string
 	fd  int
@@ -131,7 +133,7 @@ func (l *DirLock) Unlock() error {
 	return syscall.Flock(l.fd, syscall.LOCK_UN)
 }
 
-// Fd returns the lock's file descriptor
+// Fd returns the lock's file descriptor, or an error if the lock is closed
 func (l *DirLock) Fd() (int, error) {
 	var err error
 	if l.fd == -1 {

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package tar contains helper functions for working with tar files
 package tar
 
 import (
@@ -86,7 +87,7 @@ func ExtractFile(tr *tar.Reader, hdr *tar.Header, dir string, overwrite bool) er
 		}
 	}
 
-	// Create parent dir if it doesn't exists
+	// Create parent dir if it doesn't exist
 	if err := os.MkdirAll(filepath.Dir(p), DEFAULT_DIR_MODE); err != nil {
 		return err
 	}

--- a/rkt/doc.go
+++ b/rkt/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2014 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rkt (main) implements the command line interface to rocket
+package main

--- a/stage1/init/registration.go
+++ b/stage1/init/registration.go
@@ -1,3 +1,17 @@
+// Copyright 2014 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (


### PR DESCRIPTION
Also moves pkg/util/aci.go -> pkg/aci/aci.go for simplicity and consistency
with the other pkgs.