### PR TITLE
stage0: do not panic on missing app

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -154,6 +154,9 @@ func Setup(cfg Config) (string, error) {
 		if cm.Apps.Get(am.Name) != nil {
 			return "", fmt.Errorf("error: multiple apps with name %s", am.Name)
 		}
+		if am.App == nil {
+			return "", fmt.Errorf("error: image %s has no app section", img)
+		}
 		a := schema.RuntimeApp{
 			Name:        am.Name,
 			ImageID:     img,


### PR DESCRIPTION
Now that apps are an optional part of the ImageManifest, we need to check an
image contains one before accessing it.

At some point it would be nicer to check this higher up the stack, but that
will require reworking the interface between `rkt run` and stage0, so for now
just do it here.