### PR TITLE
*: switch stage1 to aci image format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ before_install:
 install:
  - go get code.google.com/p/go.tools/cmd/cover
  - go get code.google.com/p/go.tools/cmd/vet
- - go get github.com/appc/spec/schema
- - go get github.com/appc/spec/schema/types
- - go get github.com/jteeuwen/go-bindata/...
+ - go get github.com/appc/spec/...
 
 script:
  - ./test

--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -13,7 +13,6 @@
   * realpath
   * gpg
 * Go 1.3+
-  * github.com/jteeuwen/go-bindata
   * github.com/appc/spec (not yet vendored as it's in a continuous improvement phase)
 
 Once the requirements have been met you can build rocket by running the following commands:
@@ -28,5 +27,5 @@ cd rocket; ./build
 Alternatively, you can build rocket in a docker container with the following command. Replace $SRC with the absolute path to your rocket source code:
 
 ```
-$ sudo docker run -v $SRC:/opt/rocket -i -t golang:1.3 /bin/bash -c "apt-get update && apt-get install -y coreutils cpio squashfs-tools realpath && cd /opt/rocket && go get github.com/jteeuwen/go-bindata/... && go get github.com/appc/spec/... && ./build"
+$ sudo docker run -v $SRC:/opt/rocket -i -t golang:1.3 /bin/bash -c "apt-get update && apt-get install -y coreutils cpio squashfs-tools realpath && cd /opt/rocket && go get github.com/appc/spec/... && ./build"
 ```

--- a/build
+++ b/build
@@ -20,9 +20,12 @@ for d in networking/plugins/*; do
 	go install ${REPO_PATH}/$d
 done
 
+echo "Building rkt (stage0)..."
+go build -o $GOBIN/rkt ${REPO_PATH}/rkt
+
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	echo "Building init (stage1)..."
-	go build -o $GOBIN/init ${REPO_PATH}/stage1/init
+	go install ${REPO_PATH}/stage1/init
 
 	# symlink plugin binaries into stage1 rootfs
 	mkdir -p stage1/rootfs/net-plugins/bin
@@ -31,19 +34,10 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 		ln -sf ${GOBIN}/$plugin stage1/rootfs/net-plugins/bin
 	done
 
-	S1INIT=${PWD}/stage0/stage1_init
-	if [ $GOBIN/init -nt $S1INIT/bin.go ]; then
-		echo "Packaging init (stage1)..."
-		TMP=$(mktemp -d -t rocket-XXXXXX)
-		[ -d $S1INIT ] || mkdir -p $S1INIT
-		cp $GOBIN/init $TMP/s1init
-		go-bindata -nomemcopy=true -o $S1INIT/bin.go -pkg="stage1_init" -prefix=$TMP $TMP
-		rm -Rf "${TMP}"
-	fi
+	# symlink init into stage1 rootfs
+	mkdir -p stage1/rootfs/init/bin
+	ln -sf ${GOBIN}/init stage1/rootfs/init/bin
 
 	echo "Building rootfs (stage1)..."
 	make -C stage1/rootfs
 fi
-
-echo "Building rkt (stage0)..."
-go build -o $GOBIN/rkt ${REPO_PATH}/rkt

--- a/common/common.go
+++ b/common/common.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	Stage1Dir = "/stage1"
+	stage1Dir = "/stage1"
 	stage2Dir = "/opt/stage2"
 
 	MetadataSvcIP      = "169.254.169.255"
@@ -33,9 +33,20 @@ const (
 	MetadataSvcPrvPort = 2375
 )
 
-// Stage1RootfsPath returns the directory in root containing the rootfs for stage1
+// Stage1ImagePath returns the path where the stage1 app image (unpacked ACI) is rooted,
+// (i.e. where its contents are extracted during stage0).
+func Stage1ImagePath(root string) string {
+	return filepath.Join(root, stage1Dir)
+}
+
+// Stage1RootfsPath returns the path to the stage1 rootfs
 func Stage1RootfsPath(root string) string {
-	return filepath.Join(root, Stage1Dir)
+	return filepath.Join(Stage1ImagePath(root), aci.RootfsDir)
+}
+
+// Stage1ManifestPath returns the path to the stage1's manifest file inside the expanded ACI.
+func Stage1ManifestPath(root string) string {
+	return filepath.Join(Stage1ImagePath(root), aci.ManifestFile)
 }
 
 // ContainerManifestPath returns the path in root to the Container Runtime Manifest
@@ -46,7 +57,7 @@ func ContainerManifestPath(root string) string {
 // AppImagePath returns the path where an app image (i.e. unpacked ACI) is rooted (i.e.
 // where its contents are extracted during stage0), based on the app image ID.
 func AppImagePath(root string, imageID types.Hash) string {
-	return filepath.Join(root, Stage1Dir, stage2Dir, types.ShortHash(imageID.String()))
+	return filepath.Join(Stage1RootfsPath(root), stage2Dir, types.ShortHash(imageID.String()))
 }
 
 // AppRootfsPath returns the path to an app's rootfs.

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -34,7 +34,7 @@ var (
 )
 
 const (
-	statusDir     = "stage1/rkt/status"
+	statusDir     = "stage1/rootfs/rkt/status"
 	cmdStatusName = "status"
 )
 

--- a/stage0/entrypoint.go
+++ b/stage0/entrypoint.go
@@ -1,0 +1,50 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package stage0
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/appc/spec/schema"
+	"github.com/coreos/rocket/common"
+)
+
+const (
+	enterEntrypoint = "coreos.com/rocket/stage1/enter"
+	initEntrypoint  = "coreos.com/rocket/stage1/init"
+)
+
+// getEntrypoint retrieves the named entrypoint from the stage1 manifest for a given container
+func getStage1Entrypoint(cdir string, entrypoint string) (string, error) {
+	b, err := ioutil.ReadFile(common.Stage1ManifestPath(cdir))
+	if err != nil {
+		return "", fmt.Errorf("error reading container manifest: %v", err)
+	}
+
+	s1m := schema.ImageManifest{}
+	if err := json.Unmarshal(b, &s1m); err != nil {
+		return "", fmt.Errorf("error unmarshaling stage1 manifest: %v", err)
+	}
+
+	if ep, ok := s1m.Annotations.Get(entrypoint); ok {
+		return ep, nil
+	}
+
+	return "", fmt.Errorf("entrypoint %q not found", entrypoint)
+}

--- a/stage1/.gitignore
+++ b/stage1/.gitignore
@@ -1,8 +1,7 @@
 cache/
 rootfs/aggregate/install.d/
 !rootfs/aggregate/install.d/99misc
-rootfs/aggregate/s1rootfs.tar
-rootfs/aggregate/s1rootfs/
+rootfs/aggregate/stage1/
 rootfs/diagexec/diagexec
 rootfs/enter/enter
 rootfs/shim/shim.so

--- a/stage1/init/path.go
+++ b/stage1/init/path.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	unitsDir        = common.Stage1Dir + "/usr/lib/systemd/system"
+	unitsDir        = "/usr/lib/systemd/system"
 	defaultWantsDir = unitsDir + "/default.target.wants"
 	socketsWantsDir = unitsDir + "/sockets.target.wants"
 )
@@ -37,13 +37,13 @@ func ServiceUnitName(imageID types.Hash) string {
 // ServiceUnitPath returns the path to the systemd service file for the given
 // imageID
 func ServiceUnitPath(root string, imageID types.Hash) string {
-	return filepath.Join(root, unitsDir, ServiceUnitName(imageID))
+	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, ServiceUnitName(imageID))
 }
 
 // ServiceWantPath returns the systemd default.target want symlink path for the
 // given imageID
 func ServiceWantPath(root string, imageID types.Hash) string {
-	return filepath.Join(filepath.Join(root, defaultWantsDir), ServiceUnitName(imageID))
+	return filepath.Join(common.Stage1RootfsPath(root), defaultWantsDir, ServiceUnitName(imageID))
 }
 
 // SocketUnitName returns a systemd socket unit name for the given imageID
@@ -53,11 +53,11 @@ func SocketUnitName(imageID types.Hash) string {
 
 // SocketUnitPath returns the path to the systemd socket file for the given imageID
 func SocketUnitPath(root string, imageID types.Hash) string {
-	return filepath.Join(root, unitsDir, SocketUnitName(imageID))
+	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, SocketUnitName(imageID))
 }
 
 // SocketWantPath returns the systemd sockets.target.wants symlink path for the
 // given imageID
 func SocketWantPath(root string, imageID types.Hash) string {
-	return filepath.Join(filepath.Join(root, socketsWantsDir), SocketUnitName(imageID))
+	return filepath.Join(common.Stage1RootfsPath(root), socketsWantsDir, SocketUnitName(imageID))
 }

--- a/stage1/rootfs/Makefile
+++ b/stage1/rootfs/Makefile
@@ -1,4 +1,4 @@
-_SUBDIRS=usr shim diagexec enter net-plugins net
+_SUBDIRS=usr shim diagexec enter net-plugins net init
 SUBDIRS=$(_SUBDIRS) aggregate
 export CFLAGS=-Wall -Os
 

--- a/stage1/rootfs/aggregate/Makefile
+++ b/stage1/rootfs/aggregate/Makefile
@@ -1,19 +1,12 @@
-S1=s1rootfs
-S1TAR=$(S1).tar
+S1=stage1
+S1ACI=../../../bin/$(S1).aci
 
-../../../stage0/stage1_rootfs/bin.go: $(S1TAR) Makefile
-	@mkdir -p $$(dirname $@)							&& \
-	TMP=$$(mktemp -d -t stage1-XXXXXX)						&& \
-	ln -s "$(CURDIR)/$(S1TAR)" "$$TMP"						&& \
-	go-bindata -nomemcopy=true -o $@ -prefix="$$TMP" -pkg=stage1_rootfs "$$TMP"	&& \
-	rm -Rf "$$TMP"
-
-$(S1TAR): aggregate.sh Makefile scripts/* units/* install.d/*
-	@./aggregate.sh && tar cf $(S1TAR) -C $(S1) .
+$(S1ACI): aggregate.sh Makefile scripts/* units/* install.d/* aci-manifest
+	@./aggregate.sh && cp aci-manifest $(S1)/manifest && actool build --overwrite $(S1) $(S1ACI)
 
 .PHONY: clean
 clean:
-	rm -Rf $(S1) $(S1TAR)
+	rm -Rf $(S1) $(S1ACI)
 
 test:
 	echo TODO

--- a/stage1/rootfs/aggregate/aci-manifest
+++ b/stage1/rootfs/aggregate/aci-manifest
@@ -1,0 +1,29 @@
+{
+    "acKind": "ImageManifest",
+    "acVersion": "0.2.0",
+    "name": "coreos.com/rocket/stage1",
+    "labels": [
+        {
+            "name": "version",
+            "value": "0.0.1"
+        },
+        {
+            "name": "arch",
+            "value": "amd64"
+        },
+        {
+            "name": "os",
+            "value": "linux"
+        }
+    ],
+    "annotations": [
+        {
+            "name": "coreos.com/rocket/stage1/init",
+            "value": "/init"
+        },
+        {
+            "name": "coreos.com/rocket/stage1/enter",
+            "value": "/enter"
+        }
+    ]
+}

--- a/stage1/rootfs/aggregate/aggregate.sh
+++ b/stage1/rootfs/aggregate/aggregate.sh
@@ -2,7 +2,7 @@
 
 # aggregate everything into a single rootfs tree
 
-ROOT=s1rootfs
+ROOT=stage1/rootfs
 
 # always start over
 [ -e "$ROOT" ] && rm -Rf "$ROOT"

--- a/stage1/rootfs/init/Makefile
+++ b/stage1/rootfs/init/Makefile
@@ -1,0 +1,9 @@
+../aggregate/install.d/10init: Makefile install bin/init
+	@cp install ../aggregate/install.d/10init
+
+.PHONY: clean
+clean:
+	rm -f $(PLUGINS)
+
+test:
+	echo TODO

--- a/stage1/rootfs/init/install
+++ b/stage1/rootfs/init/install
@@ -1,0 +1,1 @@
+install -m 0755 ../init/bin/init "$ROOT/init"

--- a/stage1/rootfs/usr/install
+++ b/stage1/rootfs/usr/install
@@ -1,1 +1,2 @@
-cp -a ../usr/rootfs "$ROOT"
+mkdir -p "$ROOT"
+cp -a ../usr/rootfs/. "$ROOT"


### PR DESCRIPTION
One may now specify an alternative stage1 in a style like run and fetch:
rkt run --stage1-image foo.com/rocket/stage1 app

--stage1-image currently defaults to "stage1.aci", which requires running
`rkt run` from the rocket source root to use the bundled stage1.