### PR TITLE
rkt: rename c.containerWaitExited() -> c.waitExited()

### DIFF
--- a/rkt/containers.go
+++ b/rkt/containers.go
@@ -205,8 +205,8 @@ func listContainersFromDir(cdir string) ([]string, error) {
 	return cs, nil
 }
 
-// containerWaitExited waits for a container to exit.
-func (c *container) containerWaitExited() error {
+// waitExited waits for a container to exit.
+func (c *container) waitExited() error {
 	if !c.isExited {
 		if err := c.SharedLock(); err != nil {
 			return err

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -65,7 +65,7 @@ func runStatus(args []string) (exit int) {
 	defer ch.Close()
 
 	if flagWait {
-		if err := ch.containerWaitExited(); err != nil {
+		if err := ch.waitExited(); err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to wait for container: %v\n", err)
 			return 1
 		}


### PR DESCRIPTION
Should have been renamed when container became the receiver