### PR TITLE
docs: update getting started guides

### DIFF
--- a/Documentation/getting-started-guide.md
+++ b/Documentation/getting-started-guide.md
@@ -27,11 +27,18 @@ func main() {
 Next we need to build our application. We are going to statically link our app
 so we can ship an App Container Image with no external dependencies.
 
+With Go 1.3:
 ```
-$ CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w' .
+$ CGO_ENABLED=0 GOOS=linux go build -o hello -a -tags netgo -ldflags '-w' .
 ```
 
-## Create the application manifest
+or, on [Go 1.4](https://github.com/golang/go/issues/9344#issuecomment-69944514):
+
+```
+$ CGO_ENABLED=0 GOOS=linux go build -o hello -a -installsuffix cgo .
+```
+
+## Create the image manifest
 
 Edit: manifest.json
 

--- a/Documentation/getting-started-ubuntu-trusty.md
+++ b/Documentation/getting-started-ubuntu-trusty.md
@@ -1,6 +1,6 @@
 # Getting Started with Rocket on Ubuntu Trusty
 
-The following guide will show you how to build and run the sample [etcd aci](https://github.com/coreos/etcd/releases/download/v0.5.0-alpha.4/etcd-v0.5.0-alpha.4-linux-amd64.aci) on the standard vagrantcloud.com [box for ubuntu trusty](https://vagrantcloud.com/ubuntu/boxes/trusty64).
+The following guide will show you how to build and run the sample [etcd aci](https://github.com/coreos/etcd/releases/download/v2.0.0-rc.1/etcd-v2.0.0-rc.1-linux-amd64.aci) on the standard vagrantcloud.com [box for ubuntu trusty](https://vagrantcloud.com/ubuntu/boxes/trusty64).
 
 
 ## Download and start an Ubuntu Trusty box
@@ -76,7 +76,6 @@ Now try running the container and you should see output like this:
 ```
 ./rkt run https://github.com/coreos/etcd/releases/download/v2.0.0-rc.1/etcd-v2.0.0-rc.1-linux-amd64.aci
 rkt: fetching image from https://github.com/coreos/etcd/releases/download/v2.0.0-rc.1/etcd-v2.0.0-rc.1-linux-amd64.aci
-/etc/localtime is not a symlink, not updating container timezone.
 2015/01/25 04:56:34 no data-dir provided, using default data-dir ./default.etcd
 2015/01/25 04:56:34 etcd: listening for peers on http://localhost:2380
 2015/01/25 04:56:34 etcd: listening for peers on http://localhost:7001
@@ -105,4 +104,4 @@ rkt: fetching image from https://github.com/coreos/etcd/releases/download/v2.0.0
 Press ^] three times to kill container
 ```
 
-You are now running etcd inside of a rocket container on Ubuntu Trusty.
+You are now running etcd inside of a Rocket container on Ubuntu Trusty.

--- a/Documentation/getting-started-ubuntu-trusty.md
+++ b/Documentation/getting-started-ubuntu-trusty.md
@@ -1,6 +1,6 @@
 # Getting Started with Rocket on Ubuntu Trusty
 
-The following guide will show you how to build and run the sample [etcd aci](https://github.com/coreos/etcd/releases/download/v2.0.0-rc.1/etcd-v2.0.0-rc.1-linux-amd64.aci) on the standard vagrantcloud.com [box for ubuntu trusty](https://vagrantcloud.com/ubuntu/boxes/trusty64).
+The following guide will show you how to build and run the sample [etcd aci](https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.aci) on the standard vagrantcloud.com [box for ubuntu trusty](https://vagrantcloud.com/ubuntu/boxes/trusty64).
 
 
 ## Download and start an Ubuntu Trusty box
@@ -60,10 +60,10 @@ mv aci-pubkeys.gpg /etc/rkt/trustedkeys/prefix.d/coreos.com/etcd/8b86de38890ddb7
 ## Fetch the ACI
 
 ```
-./rkt fetch https://github.com/coreos/etcd/releases/download/v2.0.0-rc.1/etcd-v2.0.0-rc.1-linux-amd64.aci
-rkt: fetching image from https://github.com/coreos/etcd/releases/download/v2.0.0-rc.1/etcd-v2.0.0-rc.1-linux-amd64.aci
+./rkt fetch https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.aci
+rkt: fetching image from https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.aci
 Downloading aci: [                                             ] 16.4 KB/3.58 MB
-Downloading signature from https://github.com/coreos/etcd/releases/download/v2.0.0-rc.1/etcd-v2.0.0-rc.1-linux-amd64.sig
+Downloading signature from https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.sig
 rkt: signature verified:
   CoreOS ACI Builder <release@coreos.com>
 sha512-fcdf12587358af6ebe69b5338a05df67
@@ -74,8 +74,8 @@ sha512-fcdf12587358af6ebe69b5338a05df67
 Now try running the container and you should see output like this:
 
 ```
-./rkt run https://github.com/coreos/etcd/releases/download/v2.0.0-rc.1/etcd-v2.0.0-rc.1-linux-amd64.aci
-rkt: fetching image from https://github.com/coreos/etcd/releases/download/v2.0.0-rc.1/etcd-v2.0.0-rc.1-linux-amd64.aci
+./rkt run https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.aci
+rkt: fetching image from https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.aci
 2015/01/25 04:56:34 no data-dir provided, using default data-dir ./default.etcd
 2015/01/25 04:56:34 etcd: listening for peers on http://localhost:2380
 2015/01/25 04:56:34 etcd: listening for peers on http://localhost:7001


### PR DESCRIPTION
Add instructions for static build on go1.4, update etcd 0.5.0 -> 2.0.0

/cc @kelseyhightower