### PR TITLE
rkt: add appc spec version information

### DIFF
--- a/rkt/version.go
+++ b/rkt/version.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/appc/spec/schema"
 	"github.com/coreos/rocket/version"
 )
 
@@ -33,5 +34,6 @@ func init() {
 
 func runVersion(args []string) (exit int) {
 	fmt.Printf("rkt version %s\n", version.Version)
+	fmt.Printf("appc version %s\n", schema.AppContainerVersion)
 	return
 }


### PR DESCRIPTION
`rkt version` should print not only its own version, but version information
for the spec against which it is built.