### PR TITLE
tar: restore entry's uid and gid.

### DIFF
--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -149,6 +149,13 @@ func ExtractFile(tr *tar.Reader, hdr *tar.Header, dir string, overwrite bool) er
 		return fmt.Errorf("unsupported type: %v", typ)
 	}
 
+	// TODO(sgotti). lchown(2) says that, depending on the linux kernel
+	// version, chown can change the file mode also if executed as root.
+	// To be sure, Should we call os.Chmod after it?
+	if err := os.Lchown(p, hdr.Uid, hdr.Gid); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -45,6 +45,9 @@ func newTestTar(entries []*testTarEntry) (string, error) {
 				entry.header.Mode = 0644
 			}
 		}
+		// Add calling user uid and gid or tests will fail
+		entry.header.Uid = os.Getuid()
+		entry.header.Gid = os.Getgid()
 		if err := tw.WriteHeader(entry.header); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Restore the extracted entry uid and gid. This uses tar header Uid and Gid
values and ignores header's Uname and Gname.

As the tests are usually run as a unprivileged user the generated test tars'
entries are defaulted to the running user uid and gid. For this reason tests
are implictly verifing that the os.Chown/os.LChows calls works but it's
difficult to create a more comprehensive test using different uid and gid
values.