### PR TITLE
stage1: set app environment via diagexec instead of systemd

### DIFF
--- a/stage1/init/path.go
+++ b/stage1/init/path.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	envDir          = "/rkt/env" // TODO(vc): perhaps this doesn't belong in /rkt?
 	unitsDir        = "/usr/lib/systemd/system"
 	defaultWantsDir = unitsDir + "/default.target.wants"
 	socketsWantsDir = unitsDir + "/sockets.target.wants"
@@ -38,6 +39,17 @@ func ServiceUnitName(imageID types.Hash) string {
 // imageID
 func ServiceUnitPath(root string, imageID types.Hash) string {
 	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, ServiceUnitName(imageID))
+}
+
+// RelEnvFilePath returns the path to the environment file for the given imageID
+// relative to the container's root
+func RelEnvFilePath(imageID types.Hash) string {
+	return filepath.Join(envDir, types.ShortHash(imageID.String()))
+}
+
+// EnvFilePath returns the path to the environment file for the given imageID
+func EnvFilePath(root string, imageID types.Hash) string {
+	return filepath.Join(common.Stage1RootfsPath(root), RelEnvFilePath(imageID))
 }
 
 // ServiceWantPath returns the systemd default.target want symlink path for the

--- a/stage1/rootfs/aggregate/install.d/99misc
+++ b/stage1/rootfs/aggregate/install.d/99misc
@@ -17,3 +17,6 @@ install -d "$ROOT/opt/stage2"
 
 # dir for result code files
 install -d "$ROOT/rkt/status"
+
+# dir for env files
+install -d "$ROOT/rkt/env"

--- a/stage1/rootfs/enter/enter.c
+++ b/stage1/rootfs/enter/enter.c
@@ -89,23 +89,29 @@ int main(int argc, char *argv[])
 		"unable to fork");
 
 	if(child == 0) {
-		char		path[PATH_MAX];
+		char		root[PATH_MAX];
+		char		env[PATH_MAX];
 		char		*args[argc + 2];
 		int		i;
 
 		/* Child goes on to execute /diagexec */
 
-		exit_if(snprintf(path, sizeof(path),
-				 "/opt/stage2/%s/rootfs", argv[1]) == sizeof(path),
-			"path overflow");
+		exit_if(snprintf(root, sizeof(root),
+				 "/opt/stage2/%s/rootfs", argv[1]) == sizeof(root),
+			"root path overflow");
+
+		exit_if(snprintf(env, sizeof(env),
+				 "/rkt/env/%s", argv[1]) == sizeof(env),
+			"env path overflow");
 
 		args[0] = "/diagexec";
-		args[1] = path;
+		args[1] = root;
 		args[2] = "/";	/* TODO(vc): plumb this into app.WorkingDirectory */
+		args[3] = env;
 		for(i = 2; i < argc; i++) {
-			args[i + 1] = argv[i];
+			args[i + 2] = argv[i];
 		}
-		args[i + 1] = NULL;
+		args[i + 2] = NULL;
 
 		exit_if(execv(args[0], args) == -1,
 			"exec failed");


### PR DESCRIPTION
This change places per-app environment files in stage1/rootfs/rkt/env/$id

The stage1 systemd service files no longer contain Environment directives,
instead they simply supply the env file path to diagexec.

`rkt enter` also uses diagexec and needs to enter the same enviroment of the
app being entered.  This commit also modifies the stage1 /enter to supply the
env file to its diagexec invocation, giving `rkt enter` an environment
consistent with the app's.