### PR TITLE
rkt: fetch/trust use new API and add debug output

### DIFF
--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -74,7 +74,14 @@ func fetchImage(img string, ds *cas.Store, ks *keystore.Keystore, discover bool)
 	if err == nil && discover && u.Scheme == "" {
 		if app := newDiscoveryApp(img); app != nil {
 			fmt.Printf("rkt: searching for app image %s\n", img)
-			ep, err := discovery.DiscoverEndpoints(*app, true)
+			ep, attempts, err := discovery.DiscoverEndpoints(*app, true)
+
+			if globalFlags.Debug {
+				for _, a := range attempts {
+					fmt.Fprintf(os.Stderr, "meta tag 'ac-discovery' not found on %s: %v\n", a.Prefix, a.Error)
+				}
+			}
+
 			if err != nil {
 				return "", err
 			}

--- a/rkt/trust.go
+++ b/rkt/trust.go
@@ -157,9 +157,15 @@ func metaDiscoverPubKeyLocations(prefix string) ([]string, error) {
 		return nil, err
 	}
 
-	ep, err := discovery.DiscoverEndpoints(*app, true)
+	ep, attempts, err := discovery.DiscoverPublicKeys(*app, true)
 	if err != nil {
 		return nil, err
+	}
+
+	if globalFlags.Debug {
+		for _, a := range attempts {
+			fmt.Fprintf(os.Stderr, "meta tag 'ac-discovery-pubkeys' not found on %s: %v\n", a.Prefix, a.Error)
+		}
 	}
 
 	return ep.Keys, nil


### PR DESCRIPTION
This uses the new API that is proposed in appc/spec#173 and then also adds
debug output for the user.

```
$ ./build && sudo ./bin/rkt --debug trust  --prefix=coreos.com/etcd/asdf
meta tag 'ac-discovery-pubkeys' not found on coreos.com/etcd/asdf: expected a 200 OK got 403
meta tag 'ac-discovery-pubkeys' not found on coreos.com/etcd: expected a 200 OK got 403
Prefix: "coreos.com/etcd/asdf/asdf/asdf/asdf"
Key: "https://coreos.com/dist/pubkeys/aci-pubkeys.gpg"
GPG key fingerprint is: 8B86 DE38 890D DB72 9186  7B02 5210 BD88 8818 2190
        CoreOS ACI Builder <release@coreos.com>
Are you sure you want to trust this key (yes/no)?
```