### PR TITLE
build: build network plugins only on linux

### DIFF
--- a/build
+++ b/build
@@ -13,19 +13,19 @@ export GOPATH=${PWD}/gopath
 
 eval $(go env)
 
-echo "Building network plugins"
-for d in networking/net/* networking/ipam/*; do
-	if [ -d $d ]; then
-		plugin=$(basename $d)
-		echo "  " $plugin
-		go install ${REPO_PATH}/$d
-	fi
-done
-
 echo "Building rkt (stage0)..."
 go build -o $GOBIN/rkt ${REPO_PATH}/rkt
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	echo "Building network plugins..."
+	for d in networking/net/* networking/ipam/*; do
+		if [ -d $d ]; then
+			plugin=$(basename $d)
+			echo "  " $plugin
+			go install ${REPO_PATH}/$d
+		fi
+	done
+
 	echo "Building actool..."
 	go build -o ${GOBIN}/actool github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/actool
 	export ACTOOL=${GOBIN}/actool


### PR DESCRIPTION
Without this, go throws an error about no source files available because
all of the source files for github.com/vishvananda/netlink/nl end in
"_linux.go".