### PR TITLE
*: rename stage1 entrypoint annotation from init->run

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ where:
 - `stage1` is a copy of the stage1 ACI that is safe for read/write
 - `stage1/manifest` is the manifest of the stage1 ACI
 - `stage1/rootfs` is the rootfs of the stage1 ACI
-- `stage1/rootfs/init` is the actual stage1 binary to be executed (this path may vary according to the `coreos.com/rocket/stage1/init` Annotation of the stage1 ACI)
+- `stage1/rootfs/init` is the actual stage1 binary to be executed (this path may vary according to the `coreos.com/rocket/stage1/run` Annotation of the stage1 ACI)
 - `stage1/rootfs/opt/stage2` are copies of the unpacked ACIs
 
 At this point the stage0 execs `/stage1/rootfs/init` with the current working directory set to the root of the new filesystem.

--- a/stage0/entrypoint.go
+++ b/stage0/entrypoint.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	enterEntrypoint = "coreos.com/rocket/stage1/enter"
-	initEntrypoint  = "coreos.com/rocket/stage1/init"
+	runEntrypoint   = "coreos.com/rocket/stage1/run"
 )
 
 // getEntrypoint retrieves the named entrypoint from the stage1 manifest for a given container

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -159,7 +159,7 @@ func Run(cfg Config, dir string) {
 		log.Fatalf("failed changing to dir: %v", err)
 	}
 
-	ep, err := getStage1Entrypoint(dir, initEntrypoint)
+	ep, err := getStage1Entrypoint(dir, runEntrypoint)
 	if err != nil {
 		log.Fatalf("error determining init entrypoint: %v", err)
 	}

--- a/stage1/rootfs/aggregate/aci-manifest
+++ b/stage1/rootfs/aggregate/aci-manifest
@@ -18,7 +18,7 @@
     ],
     "annotations": [
         {
-            "name": "coreos.com/rocket/stage1/init",
+            "name": "coreos.com/rocket/stage1/run",
             "value": "/init"
         },
         {


### PR DESCRIPTION
Currently the annotation "coreos.com/rocket/stage1/init" represents the stage1
entrypoint used by `rkt run`.  Renaming to "coreos.com/rocket/stage1/run" is
more consistent and self-documenting, aligning with the `rkt enter` entrypoint
annotation "coreos.com/rocket/stage1/enter".