### PR TITLE
rkt: don't build gc.go, containers.go, and uuid.go on non-linux

### DIFF
--- a/rkt/containers.go
+++ b/rkt/containers.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//+build linux
+
 package main
 
 import (

--- a/rkt/gc.go
+++ b/rkt/gc.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//+build linux
+
 package main
 
 import (

--- a/rkt/uuid.go
+++ b/rkt/uuid.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//+build linux
+
 package main
 
 import (


### PR DESCRIPTION
Fixes #495