### PR TITLE
Default stage1 path should be configurable with a build option

### DIFF
--- a/build
+++ b/build
@@ -14,7 +14,9 @@ export GOPATH=${PWD}/gopath
 eval $(go env)
 
 echo "Building rkt (stage0)..."
-go build -o $GOBIN/rkt ${REPO_PATH}/rkt
+go build -o ${GOBIN}/rkt \
+	${RKT_STAGE1_IMAGE:+-ldflags "-X main.defaultStage1Image '${RKT_STAGE1_IMAGE}'"} \
+	${REPO_PATH}/rkt
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	echo "Building network plugins..."


### PR DESCRIPTION
As mentioned in https://github.com/coreos/rocket/issues/457#issuecomment-73944496, the path where the rkt binary looks for stage1 should be something you can specify when building rocket.

Looking at [the code](https://github.com/coreos/rocket/blob/68a0c0b6567a3e9b2feb4fbf476f1730f27b6fb5/rkt/run.go#L51-L56), this doesn't currently appear to be the case.

This is currently blocking a fix to the [Arch Linux AUR package](https://github.com/yuvadm/archlinux-packages/pull/5#issuecomment-73985648), and will probably be necessary for other distributions as well.