### PR TITLE
net: withNetNS: attempt to revert net ns in case of error

### DIFF
--- a/networking/networking.go
+++ b/networking/networking.go
@@ -250,6 +250,10 @@ func withNetNS(curNS, tgtNS *os.File, f func() error) error {
 	}
 
 	if err := f(); err != nil {
+		// Attempt to revert the net ns in a known state
+		if err := util.SetNS(curNS, syscall.CLONE_NEWNET); err != nil {
+			log.Printf("Cannot revert the net namespace: %v", err)
+		}
 		return err
 	}
 


### PR DESCRIPTION
Before this patch, when withNetNS() returns with an error, the current
net namespace is undefined. In order to make the API more readable,
withNetNS() should always at least attempt to return in a defined
namespace used before being called, even in case of errors.

In practice, the only caller of withNetNS will handle the error case
correctly by calling Teardown() so there should be no functional changes
with this patch.