### PR TITLE
fetch: require -insecure-skip-verify for Docker images

### DIFF
--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -114,9 +114,8 @@ func downloadImage(rem *cas.Remote, ds *cas.Store, ks *keystore.Keystore) (strin
 	stdout("rkt: fetching image from %s", rem.ACIURL)
 	if globalFlags.InsecureSkipVerify {
 		stdout("rkt: warning: signature verification has been disabled")
-	}
-	if rem.Scheme == "docker" {
-		fmt.Printf("rkt: warning: signature verification for docker images is not supported\n")
+	} else if rem.Scheme == "docker" {
+		return "", fmt.Errorf("signature verification for docker images is not supported (try --insecure-skip-verify)")
 	}
 	err := ds.ReadIndex(rem)
 	if err != nil && rem.BlobKey == "" {


### PR DESCRIPTION
Unfortunately since Docker images do not support signature verification, we
can't enable it for them. To make things explicit, require users to provide
the -insecure-skip-verify flag to work with Docker images.