### PR TITLE
tar: call os.Chmod after os.LChown

### DIFF
--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -149,11 +149,17 @@ func ExtractFile(tr *tar.Reader, hdr *tar.Header, dir string, overwrite bool) er
 		return fmt.Errorf("unsupported type: %v", typ)
 	}
 
-	// TODO(sgotti). lchown(2) says that, depending on the linux kernel
-	// version, chown can change the file mode also if executed as root.
-	// To be sure, Should we call os.Chmod after it?
 	if err := os.Lchown(p, hdr.Uid, hdr.Gid); err != nil {
 		return err
+	}
+
+	// lchown(2) says that, depending on the linux kernel version, it
+	// can change the file's mode also if executed as root. So call
+	// os.Chmod after it.
+	if typ != tar.TypeSymlink {
+		if err := os.Chmod(p, fi.Mode()); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fix the TODO introduced and discussed in #462 calling os.Chmod after the
os.LChown for all files except symlinks.