### PR TITLE
stage1: add systemd mount unit file for /dev

### DIFF
--- a/stage1/init/path.go
+++ b/stage1/init/path.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"strings"
+
 	"path/filepath"
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -29,6 +31,24 @@ const (
 	defaultWantsDir = unitsDir + "/default.target.wants"
 	socketsWantsDir = unitsDir + "/sockets.target.wants"
 )
+
+// MountUnitName returns a systemd mount unit name for the given imageID
+func MountUnitName(imageID types.Hash) string {
+	// Naming respecting escaping rules, see systemd.mount(5) and systemd-escape(1)
+	return "opt-stage2-" + strings.Replace(types.ShortHash(imageID.String()), "-", "\\x2d", -1) + "-rootfs-dev.mount"
+}
+
+// MountUnitPath returns the path to the systemd mount file for the given
+// imageID
+func MountUnitPath(root string, imageID types.Hash) string {
+	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, MountUnitName(imageID))
+}
+
+// MountWantPath returns the systemd default.target want symlink path for the
+// given imageID
+func MountWantPath(root string, imageID types.Hash) string {
+	return filepath.Join(common.Stage1RootfsPath(root), defaultWantsDir, MountUnitName(imageID))
+}
 
 // ServiceUnitName returns a systemd service unit name for the given imageID
 func ServiceUnitName(imageID types.Hash) string {

--- a/stage1/rootfs/usr/manifest.d/mount
+++ b/stage1/rootfs/usr/manifest.d/mount
@@ -1,0 +1,11 @@
+bin/mount
+lib64/libmount.so.1
+lib64/libmount.so.1.1.0
+lib64/libc.so.6
+lib64/libblkid.so.1
+lib64/libselinux.so.1
+lib64/ld-linux-x86-64.so.2
+lib64/libuuid.so.1
+lib64/libpcre.so.3
+lib64/libdl.so.2
+lib64/libpthread.so.0


### PR DESCRIPTION
stage1: add systemd mount unit file for /dev

systemd-nspawn already mounts /dev in the container as tmpfs and creates a few device nodes. However, they are not available to the application because the application is chrooted in /opt/stage2/sha512-xxx/rootfs/.

This patch requests systemd to bind mount /dev (the tmpfs one inside the container) to /opt/stage2/sha512-xxx/rootfs/.

Note: systemd uses /bin/mount, so it needs to be available in stage1.

The application systemd unit file is updated to depend on the mount.

This has been written as a proof of concept for: appc/spec#127

I should do the same thing for /proc and coreos/rocket#506.
