### PR TITLE
Add Vagrant support to rocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 gopath/
 *.sw[ponm]
 .DS_Store
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,12 @@
-Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
-
+Vagrant.configure('2') do |config|
+  config.vm.box = "ubuntu/trusty64" # Ubuntu 14.04
   config.vm.provision :shell, :privileged => false, :path => "scripts/install-go.sh"
+  config.vm.provision :shell, :privileged => false, :path => "scripts/install-rocket.sh"
 
+  # set auto_update to false, if you do NOT want to check the correct 
+  # additions version when booting this machine
+  config.vbguest.auto_update = true
+
+  # do NOT download the iso file from a webserver
+  config.vbguest.no_remote = true
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,6 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provision :shell, :privileged => false, :path => "scripts/install-go.sh"
+
+end

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -x
+
+export DEBIAN_FRONTEND=noninteractive
+VERSION=1.4.1
+OS=linux
+ARCH=amd64
+
+prefix=/usr/local
+
+# grab go
+if ! [ -e $prefix/go ]; then
+
+    wget -q https://storage.googleapis.com/golang/go$VERSION.$OS-$ARCH.tar.gz
+    sudo tar -C $prefix -xzf go$VERSION.$OS-$ARCH.tar.gz
+fi
+
+# setup user environment variables
+echo "export GOROOT=$prefix/go" |sudo tee /etc/profile.d/go.sh
+cat << 'EOF' |sudo tee -a /etc/profile.d/go.sh
+
+export GOPATH=$HOME/.gopath
+
+[ -e $GOPATH ] || mkdir -p $GOPATH
+
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+EOF
+
+# not essential but go get depends on it
+which git || sudo apt-get install -y git


### PR DESCRIPTION
This commit adds the necessary Vagrantfile and
associated provisioning scripts to stand-up a working
rocket installation using the Vagrant tooling.
see vagrantup.com for more details about Vagrant

Environment details:
* Ubuntu trusty 64bit (Official Image)
* golang version 1.4.1
* Rocket version 0.3.2
* APPC version 0.3.0

files directly copied from commit 03592ce of:
https://github.com/brookerj11211/vagrant-rocket