### PR TITLE
Add Vagrant support to Rocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 gopath/
 *.sw[ponm]
 .DS_Store
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,5 @@
+Vagrant.configure('2') do |config|
+  config.vm.box = "ubuntu/trusty64" # Ubuntu 14.04
+  config.vm.provision :shell, :privileged => false, :path => "scripts/install-go.sh"
+  config.vm.provision :shell, :privileged => false, :path => "scripts/install-rocket.sh"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,15 @@
 Vagrant.configure('2') do |config|
-  config.vm.box = "ubuntu/trusty64" # Ubuntu 14.04
-  config.vm.provision :shell, :privileged => false, :path => "scripts/install-go.sh"
-  config.vm.provision :shell, :privileged => false, :path => "scripts/install-rocket.sh"
+    # grab Ubuntu 14.04 official image
+    config.vm.box = "ubuntu/trusty64" # Ubuntu 14.04
+
+    # fix issues with slow dns https://www.virtualbox.org/ticket/13002
+    config.vm.provider :virtualbox do |vb, override|
+        vb.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
+    end
+
+    # install Build Dependencies (GOLANG)
+    config.vm.provision :shell, :privileged => false, :path => "scripts/install-go.sh"
+
+    # Install Rocket
+    config.vm.provision :shell, :privileged => false, :path => "scripts/install-rocket.sh"
 end

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -x
+
+export DEBIAN_FRONTEND=noninteractive
+VERSION=1.4.1
+OS=linux
+ARCH=amd64
+
+prefix=/usr/local
+
+# grab go
+if ! [ -e $prefix/go ]; then
+
+    wget -q https://storage.googleapis.com/golang/go$VERSION.$OS-$ARCH.tar.gz
+    sudo tar -C $prefix -xzf go$VERSION.$OS-$ARCH.tar.gz
+fi
+
+# setup user environment variables
+echo "export GOROOT=$prefix/go" |sudo tee /etc/profile.d/go.sh
+cat << 'EOF' |sudo tee -a /etc/profile.d/go.sh
+
+export GOPATH=$HOME/.gopath
+
+[ -e $GOPATH ] || mkdir -p $GOPATH
+
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+EOF
+
+# not essential but go get depends on it
+which git || sudo apt-get install -y git

--- a/scripts/install-rocket.sh
+++ b/scripts/install-rocket.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -xe
+export DEBIAN_FRONTEND=noninteractive
+
+ROCKET_VERSION=0.3.2
+APP_SPEC_VERSION=0.3.0
+
+if ! [ -d app-spec ]; then
+  echo "Install actool ${APP_SPEC_VERSION}"
+  mkdir app-spec
+  wget -q -O appc-spec.tar.gz https://github.com/appc/spec/archive/v${APP_SPEC_VERSION}.tar.gz
+  tar xzvf appc-spec.tar.gz -C app-spec --strip-components=1
+  pushd app-spec
+  ./build
+  sudo cp -v bin/* /usr/local/bin
+  popd
+fi
+
+if ! [ -d rocket ]; then
+  echo "Install rocket ${ROCKET_VERSION}"
+  mkdir rocket
+
+  # install deps
+  which unsquashfs || sudo apt-get install -y squashfs-tools
+
+  # grab rocket
+  wget -q -O rocket.tar.gz https://github.com/coreos/rocket/archive/v${ROCKET_VERSION}.tar.gz
+  tar xzvf rocket.tar.gz -C rocket --strip-components=1
+
+  # build/install rocket
+  pushd rocket
+  ./build
+  sudo cp -v bin/* /usr/local/bin
+  popd
+fi
+


### PR DESCRIPTION
This commit adds the necessary Vagrantfile and
associated provisioning scripts to stand-up a working
rocket installation using the Vagrant tooling.
see vagrantup.com for more details about Vagrant

Environment details:
* Ubuntu trusty 64bit (Official Image)
* golang version 1.4.1
* Rocket version 0.3.2
* APPC version 0.3.0

files directly copied from commit 03592ce of:
https://github.com/brookerj11211/vagrant-rocket