### PR TITLE
cas: check key prefix and min size in ResolveKey.

### DIFF
--- a/cas/cas.go
+++ b/cas/cas.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/aci"
@@ -48,6 +49,7 @@ const (
 	lenHash    = sha512.Size       // raw byte size
 	lenHashKey = (lenHash / 2) * 2 // half length, in hex characters
 	lenKey     = len(hashPrefix) + lenHashKey
+	minlenKey  = len(hashPrefix) + 2 // at least sha512-aa
 )
 
 var diskvStores = [...]string{
@@ -136,6 +138,12 @@ func (ds Store) tmpDir() (string, error) {
 // key by considering the key a prefix and using the store for resolution.
 // If the key is longer than the full key length, it is first truncated.
 func (ds Store) ResolveKey(key string) (string, error) {
+	if !strings.HasPrefix(key, hashPrefix) {
+		return "", fmt.Errorf("wrong key prefix")
+	}
+	if len(key) < minlenKey {
+		return "", fmt.Errorf("key too short")
+	}
 	if len(key) > lenKey {
 		key = key[:lenKey]
 	}

--- a/cas/cas_test.go
+++ b/cas/cas_test.go
@@ -195,6 +195,26 @@ func TestResolveKey(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected non-nil error!")
 	}
+
+	// wrong key prefix
+	k, err = ds.ResolveKey("badprefix-1")
+	expectedErr := "wrong key prefix"
+	if err == nil {
+		t.Errorf("expected non-nil error!")
+	}
+	if err.Error() != expectedErr {
+		t.Errorf("expected err=%q, got %q", expectedErr, err)
+	}
+
+	// key too short
+	k, err = ds.ResolveKey("sha512-1")
+	expectedErr = "key too short"
+	if err == nil {
+		t.Errorf("expected non-nil error!")
+	}
+	if err.Error() != expectedErr {
+		t.Errorf("expected err=%q, got %q", expectedErr, err)
+	}
 }
 
 func TestGetImageManifest(t *testing.T) {


### PR DESCRIPTION
Using a very short key like "sha512-a", cas.blockTransform will panic
retrieving parts[1][0:2] as part[1] will be "a" and [0:2] is out of range. As
blockTransform cannot return an error this should be checked before calling
diskv functions.

Assuming that all cas functions using diskv should be called passing a full
key (if needed retrieving it with cas.ResolveKey), this patch just adds
additional validations to cas.ResolveKey for the right prefix and a minimal
length.

A more paranoid patch should verify this before any call to diskv functions.