### PR TITLE
lock: convert DirLock to handle also locks on regular files.

### DIFF
--- a/cas/db.go
+++ b/cas/db.go
@@ -31,7 +31,7 @@ const (
 
 type DB struct {
 	dbdir string
-	lock  *lock.DirLock
+	lock  *lock.FileLock
 	sqldb *sql.DB
 }
 
@@ -47,7 +47,7 @@ func (db *DB) Open() error {
 	if db.lock != nil {
 		panic("cas db lock already gained")
 	}
-	dl, err := lock.ExclusiveLock(db.dbdir)
+	dl, err := lock.ExclusiveDirLock(db.dbdir)
 	if err != nil {
 		return err
 	}

--- a/networking/ipam/static/backend/disk/backend.go
+++ b/networking/ipam/static/backend/disk/backend.go
@@ -12,7 +12,7 @@ import (
 var defaultDataDir = "/var/lib/rkt/networks"
 
 type Store struct {
-	lock.DirLock
+	lock.FileLock
 	dataDir string
 }
 
@@ -22,7 +22,7 @@ func New(network string) (*Store, error) {
 		return nil, err
 	}
 
-	lk, err := lock.NewLock(dir)
+	lk, err := lock.NewDirLock(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lock/dir_test.go
+++ b/pkg/lock/dir_test.go
@@ -28,10 +28,11 @@ func TestNewLock(t *testing.T) {
 	defer os.Remove(f.Name())
 	f.Close()
 
-	l, err := NewLock(f.Name())
-	if err == nil || l != nil {
-		t.Fatal("expected error creating lock on file")
+	l, err := NewFileLock(f.Name())
+	if err != nil {
+		t.Fatalf("error creating NewFileLock: %v", err)
 	}
+	l.Close()
 
 	d, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -39,9 +40,9 @@ func TestNewLock(t *testing.T) {
 	}
 	defer os.Remove(d)
 
-	l, err = NewLock(d)
+	l, err = NewDirLock(d)
 	if err != nil {
-		t.Fatalf("error creating NewLock: %v", err)
+		t.Fatalf("error creating NewDirLock: %v", err)
 	}
 
 	err = l.Close()
@@ -53,7 +54,7 @@ func TestNewLock(t *testing.T) {
 		t.Fatalf("error removing tmpdir: %v", err)
 	}
 
-	l, err = NewLock(d)
+	l, err = NewDirLock(d)
 	if err == nil {
 		t.Fatalf("expected error creating lock on nonexistent path")
 	}
@@ -67,7 +68,7 @@ func TestExclusiveLock(t *testing.T) {
 	defer os.Remove(dir)
 
 	// Set up the initial exclusive lock
-	l, err := ExclusiveLock(dir)
+	l, err := ExclusiveDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating lock: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestExclusiveLock(t *testing.T) {
 	}
 
 	// Now try another exclusive lock, should fail
-	_, err = TryExclusiveLock(dir)
+	_, err = TryExclusiveDirLock(dir)
 	if err == nil {
 		t.Fatalf("expected err trying exclusive lock")
 	}
@@ -91,7 +92,7 @@ func TestExclusiveLock(t *testing.T) {
 	}
 
 	// Now another exclusive lock should succeed
-	_, err = TryExclusiveLock(dir)
+	_, err = TryExclusiveDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating lock: %v", err)
 	}
@@ -105,7 +106,7 @@ func TestSharedLock(t *testing.T) {
 	defer os.Remove(dir)
 
 	// Set up the initial shared lock
-	l1, err := SharedLock(dir)
+	l1, err := SharedDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating new shared lock: %v", err)
 	}
@@ -116,17 +117,17 @@ func TestSharedLock(t *testing.T) {
 	}
 
 	// Subsequent shared locks should succeed
-	l2, err := TrySharedLock(dir)
+	l2, err := TrySharedDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating shared lock: %v", err)
 	}
-	l3, err := TrySharedLock(dir)
+	l3, err := TrySharedDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating shared lock: %v", err)
 	}
 
 	// But an exclusive lock should fail
-	_, err = TryExclusiveLock(dir)
+	_, err = TryExclusiveDirLock(dir)
 	if err == nil {
 		t.Fatal("expected exclusive lock to fail")
 	}
@@ -148,7 +149,7 @@ func TestSharedLock(t *testing.T) {
 	}
 
 	// Now try an exclusive lock, should succeed
-	_, err = TryExclusiveLock(dir)
+	_, err = TryExclusiveDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating lock: %v", err)
 	}

--- a/rkt/containers.go
+++ b/rkt/containers.go
@@ -29,7 +29,7 @@ import (
 )
 
 type container struct {
-	*lock.DirLock
+	*lock.FileLock
 	uuid       string
 	isExited   bool
 	isGarbage  bool
@@ -84,9 +84,9 @@ func getContainer(uuid string) (*container, error) {
 		isDeleting: false,
 	}
 
-	l, err := lock.NewLock(filepath.Join(garbageDir(), uuid))
+	l, err := lock.NewDirLock(filepath.Join(garbageDir(), uuid))
 	if err == lock.ErrNotExist {
-		l, err = lock.NewLock(filepath.Join(containersDir(), uuid))
+		l, err = lock.NewDirLock(filepath.Join(containersDir(), uuid))
 		c.isGarbage = false
 		c.isExited = false
 	}
@@ -108,7 +108,7 @@ func getContainer(uuid string) (*container, error) {
 		c.isExited = true
 	}
 
-	c.DirLock = l
+	c.FileLock = l
 	cfd, err := c.Fd()
 	if err != nil {
 		c.Close()

--- a/rkt/containers_test.go
+++ b/rkt/containers_test.go
@@ -153,7 +153,7 @@ func TestWalkContainers(t *testing.T) {
 			}
 
 			if !ct.exited || ct.deleting { // acquire lock to simulate running and deleting containers
-				l, err := lock.ExclusiveLock(cp)
+				l, err := lock.ExclusiveDirLock(cp)
 				if err != nil {
 					t.Fatalf("error locking container: %v", err)
 				}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -206,7 +206,7 @@ func makeUniqueContainer(pdir string) (*types.UUID, string, error) {
 }
 
 func lockDir(dir string) error {
-	l, err := lock.TryExclusiveLock(dir)
+	l, err := lock.TryExclusiveDirLock(dir)
 	if err != nil {
 		return fmt.Errorf("error acquiring lock on dir %q: %v", dir, err)
 	}


### PR DESCRIPTION
This patch renames DirLock to FileLock (where a file can be a regular file or a
directory), adds/rename functions to create Dir o RegFile locks, and checks if
the file is correct for the request type.

I haven't renamed the files to let the reviewers be able to see the changes.