### PR TITLE
lock: add lock functions to lock by specific keys

### DIFF
--- a/cas/db.go
+++ b/cas/db.go
@@ -31,7 +31,7 @@ const (
 
 type DB struct {
 	dbdir string
-	lock  *lock.DirLock
+	lock  *lock.FileLock
 	sqldb *sql.DB
 }
 
@@ -47,7 +47,7 @@ func (db *DB) Open() error {
 	if db.lock != nil {
 		panic("cas db lock already gained")
 	}
-	dl, err := lock.ExclusiveLock(db.dbdir)
+	dl, err := lock.ExclusiveDirLock(db.dbdir)
 	if err != nil {
 		return err
 	}

--- a/networking/ipam/static/backend/disk/backend.go
+++ b/networking/ipam/static/backend/disk/backend.go
@@ -12,7 +12,7 @@ import (
 var defaultDataDir = "/var/lib/rkt/networks"
 
 type Store struct {
-	lock.DirLock
+	lock.FileLock
 	dataDir string
 }
 
@@ -22,7 +22,7 @@ func New(network string) (*Store, error) {
 		return nil, err
 	}
 
-	lk, err := lock.NewLock(dir)
+	lk, err := lock.NewDirLock(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lock/dir.go
+++ b/pkg/lock/dir.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package lock implements simple locking primitives on a
-// directory using flock
+// regular file or directory using flock
 package lock
 
 import (
@@ -22,22 +22,23 @@ import (
 )
 
 var (
-	ErrLocked     = errors.New("directory already locked")
-	ErrNotExist   = errors.New("directory does not exist")
+	ErrLocked     = errors.New("file already locked")
+	ErrNotExist   = errors.New("file does not exist")
 	ErrPermission = errors.New("permission denied")
+	ErrNotRegular = errors.New("not a regular file")
 )
 
-// DirLock represents a lock on a directory
-type DirLock struct {
-	dir string
-	fd  int
+// FileLock represents a lock on a regular file or a directory
+type FileLock struct {
+	path string
+	fd   int
 }
 
-// TryExclusiveLock takes an exclusive lock on a directory without blocking.
-// This is idempotent when the DirLock already represents an exclusive lock,
+// TryExclusiveLock takes an exclusive lock without blocking.
+// This is idempotent when the Lock already represents an exclusive lock,
 // and tries promote a shared lock to exclusive atomically.
-// It will return ErrLocked if any lock is already held on the directory.
-func (l *DirLock) TryExclusiveLock() error {
+// It will return ErrLocked if any lock is already held.
+func (l *FileLock) TryExclusiveLock() error {
 	err := syscall.Flock(l.fd, syscall.LOCK_EX|syscall.LOCK_NB)
 	if err == syscall.EWOULDBLOCK {
 		err = ErrLocked
@@ -45,10 +46,22 @@ func (l *DirLock) TryExclusiveLock() error {
 	return err
 }
 
-// TryExclusiveLock takes an exclusive lock on a directory without blocking.
+// TryExclusiveRegFileLock takes an exclusive lock on a file without blocking.
+// It will return ErrLocked if any lock is already held on the file.
+func TryExclusiveRegFileLock(path string) (*FileLock, error) {
+	return TryExclusiveLock(path, false)
+}
+
+// TryExclusiveDirLock takes an exclusive lock on a directory without blocking.
 // It will return ErrLocked if any lock is already held on the directory.
-func TryExclusiveLock(dir string) (*DirLock, error) {
-	l, err := NewLock(dir)
+func TryExclusiveDirLock(path string) (*FileLock, error) {
+	return TryExclusiveLock(path, true)
+}
+
+// TryExclusiveLock takes an exclusive lock on a file/directory without blocking.
+// It will return ErrLocked if any lock is already held on the file/directory.
+func TryExclusiveLock(path string, isDir bool) (*FileLock, error) {
+	l, err := NewLock(path, isDir)
 	if err != nil {
 		return nil, err
 	}
@@ -59,18 +72,30 @@ func TryExclusiveLock(dir string) (*DirLock, error) {
 	return l, err
 }
 
-// ExclusiveLock takes an exclusive lock on a directory.
-// This is idempotent when the DirLock already represents an exclusive lock,
+// ExclusiveLock takes an exclusive lock.
+// This is idempotent when the Lock already represents an exclusive lock,
 // and promotes a shared lock to exclusive atomically.
-// It will block if an exclusive lock is already held on the directory.
-func (l *DirLock) ExclusiveLock() error {
+// It will block if an exclusive lock is already held.
+func (l *FileLock) ExclusiveLock() error {
 	return syscall.Flock(l.fd, syscall.LOCK_EX)
 }
 
-// ExclusiveLock takes an exclusive lock on a directory.
+// ExclusiveRegFileLock takes an exclusive lock on a file.
+// It will block if an exclusive lock is already held on the file.
+func ExclusiveRegFileLock(path string) (*FileLock, error) {
+	return ExclusiveLock(path, false)
+}
+
+// ExclusiveDirLock takes an exclusive lock on a directory.
 // It will block if an exclusive lock is already held on the directory.
-func ExclusiveLock(dir string) (*DirLock, error) {
-	l, err := NewLock(dir)
+func ExclusiveDirLock(path string) (*FileLock, error) {
+	return ExclusiveLock(path, true)
+}
+
+// ExclusiveLock takes an exclusive lock on a file/directory.
+// It will block if an exclusive lock is already held on the file/directory.
+func ExclusiveLock(path string, isDir bool) (*FileLock, error) {
+	l, err := NewLock(path, isDir)
 	if err == nil {
 		err = l.ExclusiveLock()
 	}
@@ -80,11 +105,11 @@ func ExclusiveLock(dir string) (*DirLock, error) {
 	return l, nil
 }
 
-// TrySharedLock takes a co-operative (shared) lock on a directory without blocking.
-// This is idempotent when the DirLock already represents a shared lock,
+// TrySharedLock takes a co-operative (shared) lock without blocking.
+// This is idempotent when the Lock already represents a shared lock,
 // and tries demote an exclusive lock to shared atomically.
-// It will return ErrLocked if an exclusive lock already exists on the directory.
-func (l *DirLock) TrySharedLock() error {
+// It will return ErrLocked if an exclusive lock already exists.
+func (l *FileLock) TrySharedLock() error {
 	err := syscall.Flock(l.fd, syscall.LOCK_SH|syscall.LOCK_NB)
 	if err == syscall.EWOULDBLOCK {
 		err = ErrLocked
@@ -92,10 +117,22 @@ func (l *DirLock) TrySharedLock() error {
 	return err
 }
 
-// TrySharedLock takes a co-operative (shared) lock on a directory without blocking.
+// TrySharedRegFileLock takes a co-operative (shared) lock on a file without blocking.
+// It will return ErrLocked if an exclusive lock already exists on the file.
+func TrySharedRegFileLock(path string) (*FileLock, error) {
+	return TrySharedLock(path, false)
+}
+
+// TrySharedDirLock takes a co-operative (shared) lock on a directory without blocking.
 // It will return ErrLocked if an exclusive lock already exists on the directory.
-func TrySharedLock(dir string) (*DirLock, error) {
-	l, err := NewLock(dir)
+func TrySharedDirLock(path string) (*FileLock, error) {
+	return TrySharedLock(path, true)
+}
+
+// TrySharedLock takes a co-operative (shared) lock on a file/directory without blocking.
+// It will return ErrLocked if an exclusive lock already exists on the file/directory.
+func TrySharedLock(path string, isDir bool) (*FileLock, error) {
+	l, err := NewLock(path, isDir)
 	if err != nil {
 		return nil, err
 	}
@@ -106,18 +143,30 @@ func TrySharedLock(dir string) (*DirLock, error) {
 	return l, nil
 }
 
-// SharedLock takes a co-operative (shared) lock on a directory.
-// This is idempotent when the DirLock already represents a shared lock,
+// SharedLock takes a co-operative (shared) lock on.
+// This is idempotent when the Lock already represents a shared lock,
 // and demotes an exclusive lock to shared atomically.
-// It will block if an exclusive lock is already held on the directory.
-func (l *DirLock) SharedLock() error {
+// It will block if an exclusive lock is already held.
+func (l *FileLock) SharedLock() error {
 	return syscall.Flock(l.fd, syscall.LOCK_SH)
 }
 
-// SharedLock takes a co-operative (shared) lock on a directory.
+// SharedRegFileLock takes a co-operative (shared) lock on a file.
+// It will block if an exclusive lock is already held on the file.
+func SharedRegFileLock(path string) (*FileLock, error) {
+	return TrySharedLock(path, false)
+}
+
+// SharedDirLock takes a co-operative (shared) lock on a directory.
 // It will block if an exclusive lock is already held on the directory.
-func SharedLock(dir string) (*DirLock, error) {
-	l, err := NewLock(dir)
+func SharedDirLock(path string) (*FileLock, error) {
+	return TrySharedLock(path, true)
+}
+
+// SharedLock takes a co-operative (shared) lock on a file/directory.
+// It will block if an exclusive lock is already held on the file/directory.
+func SharedLock(path string, isDir bool) (*FileLock, error) {
+	l, err := NewLock(path, isDir)
 	if err != nil {
 		return nil, err
 	}
@@ -129,12 +178,12 @@ func SharedLock(dir string) (*DirLock, error) {
 }
 
 // Unlock unlocks the lock
-func (l *DirLock) Unlock() error {
+func (l *FileLock) Unlock() error {
 	return syscall.Flock(l.fd, syscall.LOCK_UN)
 }
 
 // Fd returns the lock's file descriptor, or an error if the lock is closed
-func (l *DirLock) Fd() (int, error) {
+func (l *FileLock) Fd() (int, error) {
 	var err error
 	if l.fd == -1 {
 		err = errors.New("lock closed")
@@ -143,18 +192,22 @@ func (l *DirLock) Fd() (int, error) {
 }
 
 // Close closes the lock which implicitly unlocks it as well
-func (l *DirLock) Close() error {
+func (l *FileLock) Close() error {
 	fd := l.fd
 	l.fd = -1
 	return syscall.Close(fd)
 }
 
-// NewLock opens a new lock on a directory without acquisition
-func NewLock(dir string) (*DirLock, error) {
-	l := &DirLock{dir: dir, fd: -1}
+// NewLock opens a new lock on a file without acquisition
+func NewLock(path string, isDir bool) (*FileLock, error) {
+	l := &FileLock{path: path, fd: -1}
 
+	mode := syscall.O_RDONLY
+	if isDir {
+		mode |= syscall.O_DIRECTORY
+	}
 	// we can't use os.OpenFile as Go sets O_CLOEXEC
-	lfd, err := syscall.Open(l.dir, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
+	lfd, err := syscall.Open(l.path, mode, 0)
 	if err != nil {
 		if err == syscall.ENOENT {
 			err = ErrNotExist
@@ -165,5 +218,23 @@ func NewLock(dir string) (*DirLock, error) {
 	}
 	l.fd = lfd
 
+	var stat syscall.Stat_t
+	err = syscall.Fstat(lfd, &stat)
+	if err != nil {
+		return nil, err
+	}
+	// Check if the file is a regular file
+	if !isDir && !(stat.Mode&syscall.S_IFMT == syscall.S_IFREG) {
+		return nil, ErrNotRegular
+	}
+
 	return l, nil
+}
+
+func NewDirLock(path string) (*FileLock, error) {
+	return NewLock(path, true)
+}
+
+func NewFileLock(path string) (*FileLock, error) {
+	return NewLock(path, false)
 }

--- a/pkg/lock/dir_test.go
+++ b/pkg/lock/dir_test.go
@@ -28,10 +28,11 @@ func TestNewLock(t *testing.T) {
 	defer os.Remove(f.Name())
 	f.Close()
 
-	l, err := NewLock(f.Name())
-	if err == nil || l != nil {
-		t.Fatal("expected error creating lock on file")
+	l, err := NewFileLock(f.Name())
+	if err != nil {
+		t.Fatalf("error creating NewFileLock: %v", err)
 	}
+	l.Close()
 
 	d, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -39,9 +40,9 @@ func TestNewLock(t *testing.T) {
 	}
 	defer os.Remove(d)
 
-	l, err = NewLock(d)
+	l, err = NewDirLock(d)
 	if err != nil {
-		t.Fatalf("error creating NewLock: %v", err)
+		t.Fatalf("error creating NewDirLock: %v", err)
 	}
 
 	err = l.Close()
@@ -53,7 +54,7 @@ func TestNewLock(t *testing.T) {
 		t.Fatalf("error removing tmpdir: %v", err)
 	}
 
-	l, err = NewLock(d)
+	l, err = NewDirLock(d)
 	if err == nil {
 		t.Fatalf("expected error creating lock on nonexistent path")
 	}
@@ -67,7 +68,7 @@ func TestExclusiveLock(t *testing.T) {
 	defer os.Remove(dir)
 
 	// Set up the initial exclusive lock
-	l, err := ExclusiveLock(dir)
+	l, err := ExclusiveDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating lock: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestExclusiveLock(t *testing.T) {
 	}
 
 	// Now try another exclusive lock, should fail
-	_, err = TryExclusiveLock(dir)
+	_, err = TryExclusiveDirLock(dir)
 	if err == nil {
 		t.Fatalf("expected err trying exclusive lock")
 	}
@@ -91,7 +92,7 @@ func TestExclusiveLock(t *testing.T) {
 	}
 
 	// Now another exclusive lock should succeed
-	_, err = TryExclusiveLock(dir)
+	_, err = TryExclusiveDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating lock: %v", err)
 	}
@@ -105,7 +106,7 @@ func TestSharedLock(t *testing.T) {
 	defer os.Remove(dir)
 
 	// Set up the initial shared lock
-	l1, err := SharedLock(dir)
+	l1, err := SharedDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating new shared lock: %v", err)
 	}
@@ -116,17 +117,17 @@ func TestSharedLock(t *testing.T) {
 	}
 
 	// Subsequent shared locks should succeed
-	l2, err := TrySharedLock(dir)
+	l2, err := TrySharedDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating shared lock: %v", err)
 	}
-	l3, err := TrySharedLock(dir)
+	l3, err := TrySharedDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating shared lock: %v", err)
 	}
 
 	// But an exclusive lock should fail
-	_, err = TryExclusiveLock(dir)
+	_, err = TryExclusiveDirLock(dir)
 	if err == nil {
 		t.Fatal("expected exclusive lock to fail")
 	}
@@ -148,7 +149,7 @@ func TestSharedLock(t *testing.T) {
 	}
 
 	// Now try an exclusive lock, should succeed
-	_, err = TryExclusiveLock(dir)
+	_, err = TryExclusiveDirLock(dir)
 	if err != nil {
 		t.Fatalf("error creating lock: %v", err)
 	}

--- a/pkg/lock/keylock.go
+++ b/pkg/lock/keylock.go
@@ -1,0 +1,208 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	defaultDirPerm  os.FileMode = 0660
+	defaultFilePerm os.FileMode = 0660
+	lockRetry                   = 3
+)
+
+// KeyLock is a lock for a specific key. The locks files are created inside a
+// directory using the key name.
+// The key name must be a valid file name.
+type KeyLock struct {
+	lockDir string
+	key     string
+	// The lock on the key
+	keyLock *FileLock
+}
+
+// NewKeyLock returns a KeyLock for the specified key without acquisition.
+// lockdir is the directory where the lock file will be created. If lockdir
+// doesn't exists it will be created.
+// The key name must be a valid file name.
+func NewKeyLock(lockDir string, key string) (*KeyLock, error) {
+	err := os.MkdirAll(lockDir, defaultDirPerm)
+	if err != nil {
+		return nil, err
+	}
+	keyLockFile := filepath.Join(lockDir, key)
+	// create the file if it doesn't exists
+	f, err := os.OpenFile(keyLockFile, os.O_RDONLY|os.O_CREATE, defaultFilePerm)
+	if err != nil {
+		return nil, fmt.Errorf("error creating key lock file: %v", err)
+	}
+	f.Close()
+	keyLock, err := NewFileLock(keyLockFile)
+	if err != nil {
+		return nil, fmt.Errorf("error opening key lock file: %v", err)
+	}
+	return &KeyLock{lockDir: lockDir, key: key, keyLock: keyLock}, nil
+}
+
+// Close closes the key lock which implicitly unlocks it as well
+func (l *KeyLock) Close() {
+	l.keyLock.Close()
+}
+
+// TryExclusiveLock takes an exclusive lock on a key without blocking.
+// This is idempotent when the KeyLock already represents an exclusive lock,
+// and tries promote a shared lock to exclusive atomically.
+// It will return ErrLocked if any lock is already held on the key.
+func (l *KeyLock) TryExclusiveKeyLock() error {
+	return l.lock(true, true)
+}
+
+// TryExclusiveLock takes an exclusive lock on the key without blocking.
+// lockDir is the directory where the lock file will be created.
+// It will return ErrLocked if any lock is already held.
+func TryExclusiveKeyLock(lockDir string, key string) (*KeyLock, error) {
+	return createAndLock(lockDir, key, true, true)
+}
+
+// ExclusiveLock takes an exclusive lock on a key.
+// This is idempotent when the KeyLock already represents an exclusive lock,
+// and promotes a shared lock to exclusive atomically.
+// It will block if an exclusive lock is already held on the key.
+func (l *KeyLock) ExclusiveKeyLock() error {
+	return l.lock(false, true)
+}
+
+// ExclusiveLock takes an exclusive lock on a key.
+// lockDir is the directory where the lock file will be created.
+// It will block if an exclusive lock is already held on the key.
+func ExclusiveKeyLock(lockDir string, key string) (*KeyLock, error) {
+	return createAndLock(lockDir, key, false, true)
+}
+
+// TrySharedLock takes a co-operative (shared) lock on the key without blocking.
+// This is idempotent when the KeyLock already represents a shared lock,
+// and tries demote an exclusive lock to shared atomically.
+// It will return ErrLocked if an exclusive lock already exists on the key.
+func (l *KeyLock) TrySharedKeyLock() error {
+	return l.lock(true, false)
+}
+
+// TrySharedLock takes a co-operative (shared) lock on a key without blocking.
+// lockDir is the directory where the lock file will be created.
+// It will return ErrLocked if an exclusive lock already exists on the key.
+func TrySharedKeyLock(lockDir string, key string) (*KeyLock, error) {
+	return createAndLock(lockDir, key, true, false)
+}
+
+// SharedLock takes a co-operative (shared) lock on a key.
+// This is idempotent when the KeyLock already represents a shared lock,
+// and demotes an exclusive lock to shared atomically.
+// It will block if an exclusive lock is already held on the key.
+func (l *KeyLock) SharedKeyLock() error {
+	return l.lock(false, false)
+}
+
+// SharedLock takes a co-operative (shared) lock on a key.
+// lockDir is the directory where the lock file will be created.
+// It will block if an exclusive lock is already held on the key.
+func SharedKeyLock(lockDir string, key string) (*KeyLock, error) {
+	return createAndLock(lockDir, key, false, false)
+}
+
+func createAndLock(lockDir string, key string, try bool, exclusive bool) (*KeyLock, error) {
+	keyLock, err := NewKeyLock(lockDir, key)
+	if err != nil {
+		return nil, err
+	}
+	err = keyLock.lock(try, exclusive)
+	if err != nil {
+		return nil, err
+	}
+	return keyLock, nil
+}
+
+func (l *KeyLock) lock(try bool, exclusive bool) error {
+	var err error
+	for retry := 0; retry < lockRetry; retry++ {
+		switch {
+		case exclusive && !try:
+			err = l.keyLock.ExclusiveLock()
+		case exclusive && try:
+			err = l.keyLock.TryExclusiveLock()
+		case !exclusive && !try:
+			err = l.keyLock.SharedLock()
+		case !exclusive && try:
+			err = l.keyLock.TrySharedLock()
+		}
+
+		if err == ErrFileChanged {
+			l.keyLock.Close()
+			nl, err := NewKeyLock(l.lockDir, l.key)
+			if err != nil {
+				return err
+			}
+			l.keyLock = nl.keyLock
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Unlock unlocks the key lock and the lockDir lock.
+func (l *KeyLock) Unlock() error {
+	err := l.keyLock.Unlock()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// CleanKeyLocks remove lock files from the lockDir.
+// For every key it tries to take an Exclusive lock on it and skip it if it
+// fails with ErrLocked
+func CleanKeyLocks(lockDir string) error {
+	f, err := os.Open(lockDir)
+	if err != nil {
+		return fmt.Errorf("error opening lockDir: %v", err)
+	}
+	defer f.Close()
+	files, err := f.Readdir(0)
+	if err != nil {
+		return fmt.Errorf("error getting lock files list: %v", err)
+	}
+	for _, f := range files {
+		filename := filepath.Join(lockDir, f.Name())
+		keyLock, err := TryExclusiveKeyLock(lockDir, f.Name())
+		if err == ErrLocked {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+
+		err = os.Remove(filename)
+		if err != nil {
+			keyLock.Close()
+			return fmt.Errorf("error removing lock file: %v", err)
+		}
+		keyLock.Close()
+	}
+	return nil
+}

--- a/pkg/lock/keylock_test.go
+++ b/pkg/lock/keylock_test.go
@@ -1,0 +1,100 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lock
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestExclusiveKeyLock(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("error creating tmpdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	l1, err := ExclusiveKeyLock(dir, "key01")
+	if err != nil {
+		t.Fatalf("error creating key lock: %v", err)
+	}
+
+	_, err = TryExclusiveKeyLock(dir, "key01")
+	if err == nil {
+		t.Fatalf("expected err trying exclusive key lock")
+	}
+
+	l1.Close()
+}
+
+func TestCleanKeyLocks(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("error creating tmpdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	l1, err := ExclusiveKeyLock(dir, "key01")
+	if err != nil {
+		t.Fatalf("error creating keyLock: %v", err)
+	}
+
+	err = CleanKeyLocks(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	filesnum, err := countFiles(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if filesnum != 1 {
+		t.Fatalf("expected 1 file in lock dir. found %d files", filesnum)
+	}
+
+	l2, err := SharedKeyLock(dir, "key02")
+	if err != nil {
+		t.Fatalf("error creating keyLock: %v", err)
+	}
+
+	l1.Close()
+	l2.Close()
+
+	err = CleanKeyLocks(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	filesnum, err = countFiles(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if filesnum != 0 {
+		t.Fatalf("expected empty lock dir. found %d files", filesnum)
+	}
+}
+
+func countFiles(dir string) (int, error) {
+	f, err := os.Open(dir)
+	if err != nil {
+		return -1, err
+	}
+	defer f.Close()
+	files, err := f.Readdir(0)
+	if err != nil {
+		return -1, err
+	}
+	return len(files), nil
+}

--- a/rkt/containers.go
+++ b/rkt/containers.go
@@ -29,7 +29,7 @@ import (
 )
 
 type container struct {
-	*lock.DirLock
+	*lock.FileLock
 	uuid       string
 	isExited   bool
 	isGarbage  bool
@@ -84,9 +84,9 @@ func getContainer(uuid string) (*container, error) {
 		isDeleting: false,
 	}
 
-	l, err := lock.NewLock(filepath.Join(garbageDir(), uuid))
+	l, err := lock.NewDirLock(filepath.Join(garbageDir(), uuid))
 	if err == lock.ErrNotExist {
-		l, err = lock.NewLock(filepath.Join(containersDir(), uuid))
+		l, err = lock.NewDirLock(filepath.Join(containersDir(), uuid))
 		c.isGarbage = false
 		c.isExited = false
 	}
@@ -108,7 +108,7 @@ func getContainer(uuid string) (*container, error) {
 		c.isExited = true
 	}
 
-	c.DirLock = l
+	c.FileLock = l
 	cfd, err := c.Fd()
 	if err != nil {
 		c.Close()

--- a/rkt/containers_test.go
+++ b/rkt/containers_test.go
@@ -153,7 +153,7 @@ func TestWalkContainers(t *testing.T) {
 			}
 
 			if !ct.exited || ct.deleting { // acquire lock to simulate running and deleting containers
-				l, err := lock.ExclusiveLock(cp)
+				l, err := lock.ExclusiveDirLock(cp)
 				if err != nil {
 					t.Fatalf("error locking container: %v", err)
 				}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -206,7 +206,7 @@ func makeUniqueContainer(pdir string) (*types.UUID, string, error) {
 }
 
 func lockDir(dir string) error {
-	l, err := lock.TryExclusiveLock(dir)
+	l, err := lock.TryExclusiveDirLock(dir)
 	if err != nil {
 		return fmt.Errorf("error acquiring lock on dir %q: %v", dir, err)
 	}


### PR DESCRIPTION
Last patch is the interesting one (the other one is provided by #574)

This adds a KeyLock struct and related functions trying to keep the same
semantic of DirLock.
It'll be useful for diskv file locking, for download locking and for every
need to lock something that isn't referenceable with a specific and already
available path on the filesystem.

KeyLock is a lock for a specific key. The locks files are created inside a
directory using the key name.
The key name must be a valid file name.

This uses a diffrent behavior than #570 changing FileLock to check if the file is changed between opening and acquiring the lock. This will avoid locking the lockDir and make keylock able to selectively remove unused lock files.