### PR TITLE
tests: don't use an AC name finishing with a slash

### DIFF
--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -93,9 +93,9 @@ func TestNewDiscoveryApp(t *testing.T) {
 		},
 		// combinations
 		{
-			"one.two/:three,os=four,foo=five,arch=six",
+			"one.two/appname:three,os=four,foo=five,arch=six",
 			&discovery.App{
-				Name: "one.two/",
+				Name: "one.two/appname",
 				Labels: map[string]string{
 					"version": "three",
 					"os":      "four",


### PR DESCRIPTION
The appc spec does not allow it anymore:
https://github.com/appc/spec/commit/14f48a22af6a013afe7848844a66f0ca6aac9af6