### PR TITLE
rkt: use .asc instead of .sig files

### DIFF
--- a/Documentation/signing-and-verification-guide.md
+++ b/Documentation/signing-and-verification-guide.md
@@ -113,7 +113,7 @@ $ gpg --no-default-keyring --armor \
 ```
 $ gpg --no-default-keyring --armor \
 --secret-keyring ./rocket.sec --keyring ./rocket.pub \
---output hello-0.0.1-linux-amd64.sig \
+--output hello-0.0.1-linux-amd64.aci.asc \
 --detach-sig hello-0.0.1-linux-amd64.aci
 ```
 
@@ -122,7 +122,7 @@ $ gpg --no-default-keyring --armor \
 ```
 $ gpg --no-default-keyring \
 --secret-keyring ./rocket.sec --keyring ./rocket.pub \
---verify hello-0.0.1-linux-amd64.sig hello-0.0.1-linux-amd64.aci
+--verify hello-0.0.1-linux-amd64.aci.asc hello-0.0.1-linux-amd64.aci
 ```
 ```
 gpg: Signature made Fri Jan  9 05:01:49 2015 PST using RSA key ID 26EF7A14
@@ -132,7 +132,7 @@ gpg: Good signature from "Kelsey Hightower (ACI signing key) <kelsey.hightower@c
 At this point you should have the following three files:
 
 ```
-hello-0.0.1-linux-amd64.sig
+hello-0.0.1-linux-amd64.aci.asc
 hello-0.0.1-linux-amd64.aci
 pubkeys.gpg
 ```
@@ -155,7 +155,7 @@ Host an HTML page with the following meta tags:
 Serve the following files at the locations described in the meta tags:
 
 ```
-https://example.com/images/hello-0.0.1-linux-amd64.sig
+https://example.com/images/hello-0.0.1-linux-amd64.aci.asc
 https://example.com/images/hello-0.0.1-linux-amd64.aci
 https://example.com/pubkeys.gpg
 ```
@@ -174,7 +174,7 @@ results in rocket retrieving the following URIs:
 ```
 https://example.com/hello?ac-discovery=1
 https://example.com/images/example.com/hello-0.0.1-linux-amd64.aci
-https://example.com/images/example.com/hello-0.0.1-linux-amd64.sig
+https://example.com/images/example.com/hello-0.0.1-linux-amd64.aci.asc
 ```
 
 The first response contains the template URL used to download the ACI image and detached signature file.
@@ -185,7 +185,7 @@ The first response contains the template URL used to download the ACI image and 
 
 Rocket populates the `{os}` and `{arch}` based on the current running system.
 The `{version}` will be taken from the tag given on the command line or "latest" if not supplied.
-The `{ext}` will be substituted appropriately depending on artifact being retrieved: .aci will be used for ACI images and .sig will be used for detached signatures.
+The `{ext}` will be substituted appropriately depending on artifact being retrieved: .aci will be used for ACI images and .aci.asc will be used for detached signatures.
 
 Once the ACI image has been downloaded rocket will extract the image's name from the image metadata. The image's name will be used to locate trusted public keys in the rocket keystore and perform signature validation.
 

--- a/README.md
+++ b/README.md
@@ -50,24 +50,24 @@ A detailed, step-by-step guide for the signing procedure [is here](Documentation
 Now that we've trusted the CoreOS public key, we can fetch the ACI:
 
 ```
-$ sudo rkt fetch coreos.com/etcd:v2.0.0
-rkt: searching for app image coreos.com/etcd:v2.0.0
-rkt: fetching image from https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.aci
+$ sudo rkt fetch coreos.com/etcd:v2.0.4
+rkt: searching for app image coreos.com/etcd:v2.0.4
+rkt: fetching image from https://github.com/coreos/etcd/releases/download/v2.0.4/etcd-v2.0.4-linux-amd64.aci
 Downloading aci: [==========================================   ] 3.47 MB/3.7 MB
-Downloading signature from https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.sig
+Downloading signature from https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.4-linux-amd64.aci.asc
 rkt: signature verified: 
   CoreOS ACI Builder <release@coreos.com>
-sha512-fa1cb92dc276b0f9bedf87981e61ecde
+sha512-1eba37d9b344b33d272181e176da111e
 ```
 
 These files are now written to disk:
 
 ```
-[~]$ find /var/lib/rkt/cas/blob/
+$ find /var/lib/rkt/cas/blob/
 /var/lib/rkt/cas/blob/
 /var/lib/rkt/cas/blob/sha512
-/var/lib/rkt/cas/blob/sha512/fa
-/var/lib/rkt/cas/blob/sha512/fa/sha512-fa1cb92dc276b0f9bedf87981e61ecde93cc16432d2441f23aa006a42bb873df
+/var/lib/rkt/cas/blob/sha512/1e
+/var/lib/rkt/cas/blob/sha512/1e/sha512-1eba37d9b344b33d272181e176da111ef2fdd4958b88ba4071e56db9ac07cf62
 ```
 
 Per the [App Container Specification](https://github.com/appc/spec/blob/master/SPEC.md#image-archives), the SHA-512 hash is of the tarball and can be reproduced with other tools:
@@ -77,7 +77,7 @@ $ wget https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux
 ...
 $ gzip -dc etcd-v2.0.0-linux-amd64.aci > etcd-v2.0.0-linux-amd64.tar
 $ sha512sum etcd-v2.0.0-linux-amd64.tar
-fa1cb92dc276b0f9bedf87981e61ecde93cc16432d2441f23aa006a42bb873dfc67480dafb0dfb33b91fd848e138268f71e1f32b55e197cdc2d874ae8da01bbe  etcd-v2.0.0-linux-amd64.tar
+1eba37d9b344b33d272181e176da111ef2fdd4958b88ba4071e56db9ac07cf62cce3daaee03ebd92dfbb596fe7879938374c671ae768cd927bab7b16c5e432e8  etcd-v2.0.4-linux-amd64.tar
 ```
 
 ### Launching an ACI
@@ -86,14 +86,14 @@ After it has been retrieved and stored locally, an ACI can be run by pointing `r
 
 ```
 # Example of running via ACI hash
-$ sudo rkt run sha512-fa1cb92dc276b0f9bedf87981e61ecde
+$ sudo rkt run sha512-1eba37d9b344b33d272181e176da111e
 ...
 Press ^] three times to kill container
 ```
 
 ```
 # Example of running via ACI URL
-$ sudo rkt run https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.aci
+$ sudo rkt run https://github.com/coreos/etcd/releases/download/v2.0.4/etcd-v2.0.4-linux-amd64.aci
 ...
 Press ^] three times to kill container
 ```

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -109,10 +109,10 @@ func fetchImageFromEndpoints(ep *discovery.Endpoints, ds *cas.Store, ks *keystor
 }
 
 func fetchImageFromURL(imgurl string, scheme string, ds *cas.Store, ks *keystore.Keystore) (string, error) {
-	return downloadImage(imgurl, sigURLFromImgURL(imgurl), scheme, ds, ks)
+	return downloadImage(imgurl, ascURLFromImgURL(imgurl), scheme, ds, ks)
 }
 
-func downloadImage(aciURL string, sigURL string, scheme string, ds *cas.Store, ks *keystore.Keystore) (string, error) {
+func downloadImage(aciURL string, ascURL string, scheme string, ds *cas.Store, ks *keystore.Keystore) (string, error) {
 	stdout("rkt: fetching image from %s", aciURL)
 	if globalFlags.InsecureSkipVerify {
 		stdout("rkt: warning: signature verification has been disabled")
@@ -124,7 +124,7 @@ func downloadImage(aciURL string, sigURL string, scheme string, ds *cas.Store, k
 		return "", err
 	}
 	if !ok {
-		rem = cas.NewRemote(aciURL, sigURL)
+		rem = cas.NewRemote(aciURL, ascURL)
 		entity, aciFile, err := rem.Download(*ds, ks)
 		if err != nil {
 			return "", err
@@ -156,9 +156,9 @@ func validateURL(s string) error {
 	return nil
 }
 
-func sigURLFromImgURL(imgurl string) string {
+func ascURLFromImgURL(imgurl string) string {
 	s := strings.TrimSuffix(imgurl, ".aci")
-	return s + ".sig"
+	return s + ".aci.asc"
 }
 
 // newDiscoveryApp creates a discovery app if the given img is an app name and

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -146,7 +146,7 @@ func TestFetchImage(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
-	sig, err := aci.NewDetachedSignature(key.ArmoredPrivateKey, a)
+	asc, err := aci.NewDetachedSignature(key.ArmoredPrivateKey, a)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -161,9 +161,11 @@ func TestFetchImage(t *testing.T) {
 		case ".aci":
 			io.Copy(w, a)
 			return
-		case ".sig":
-			io.Copy(w, sig)
+		case ".asc":
+			io.Copy(w, asc)
 			return
+		default:
+			t.Fatalf("unknown extension %v", r.URL.Path)
 		}
 	}))
 	defer ts.Close()
@@ -179,11 +181,11 @@ func TestSigURLFromImgURL(t *testing.T) {
 	}{
 		{
 			"http://localhost/aci-latest-linux-amd64.aci",
-			"http://localhost/aci-latest-linux-amd64.sig",
+			"http://localhost/aci-latest-linux-amd64.aci.asc",
 		},
 	}
 	for i, tt := range tests {
-		out := sigURLFromImgURL(tt.in)
+		out := ascURLFromImgURL(tt.in)
 		if out != tt.out {
 			t.Errorf("#%d: got %v, want %v", i, out, tt.out)
 		}


### PR DESCRIPTION
Use the standard PGP file extension of .asc instead of .sig. This was
changed in the the 0.4.0 spec.