### PR TITLE
Godep: bump appc/spec to 0.4.0

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -25,33 +25,33 @@
 		},
 		{
 			"ImportPath": "github.com/appc/spec/aci",
-			"Comment": "v0.3.0-88-g480f581",
-			"Rev": "480f5812e40cb93dbc5270301092368952546bb1"
+			"Comment": "v0.4.0",
+			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/actool",
-			"Comment": "v0.3.0-88-g480f581",
-			"Rev": "480f5812e40cb93dbc5270301092368952546bb1"
+			"Comment": "v0.4.0",
+			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/discovery",
-			"Comment": "v0.3.0-88-g480f581",
-			"Rev": "480f5812e40cb93dbc5270301092368952546bb1"
+			"Comment": "v0.4.0",
+			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/acirenderer",
-			"Comment": "v0.3.0-88-g480f581",
-			"Rev": "480f5812e40cb93dbc5270301092368952546bb1"
+			"Comment": "v0.4.0",
+			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/tarheader",
-			"Comment": "v0.3.0-88-g480f581",
-			"Rev": "480f5812e40cb93dbc5270301092368952546bb1"
+			"Comment": "v0.4.0",
+			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/schema",
-			"Comment": "v0.3.0-88-g480f581",
-			"Rev": "480f5812e40cb93dbc5270301092368952546bb1"
+			"Comment": "v0.4.0",
+			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
 		},
 		{
 			"ImportPath": "github.com/camlistore/lock",

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
@@ -8,7 +8,7 @@ const (
 	// version represents the canonical version of the appc spec and tooling.
 	// For now, the schema and tooling is coupled with the spec itself, so
 	// this must be kept in sync with the VERSION file in the root of the repo.
-	version string = "0.3.0+git"
+	version string = "0.4.0"
 )
 
 var (


### PR DESCRIPTION
This is basically a no-op because the only changes since 
480f5812e40cb93dbc5270301092368952546bb1 don't touch the vendored code, but it
gets in sync with the actual release.