### PR TITLE
rkt: add --set-env to `rkt run` and `rkt prepare`

### DIFF
--- a/Documentation/commands.md
+++ b/Documentation/commands.md
@@ -166,19 +166,25 @@ For example:
 $ sudo rkt run example.com/worker -- --loglevel verbose --- example.com/syncer -- --interval 30s
 ```
 
-#### Inheriting Environment Variables
+#### Influencing Environment Variables
 
-To inherit environment variables from the parent use the `--inherit-environment` flag.
+To inherit all environment variables from the parent use the `--inherit-env` flag.
 
-The inheritance precedence is as follows with the last item replacing previous environment entries:
+To explicitly set individual environment variables use the `--set-env` flag.
+
+The precedence is as follows with the last item replacing previous environment entries:
 
 - Parent environment
 - App image environment
+- Explicitly set environment
 
 ```
 $ export EXAMPLE_ENV=hello
-$ sudo rkt run --inherit-environment example.com/env-printer
+$ export EXAMPLE_OVERRIDE=under
+$ sudo rkt run --inherit-env --set-env FOO=bar --set-env EXAMPLE_OVERRIDE=over example.com/env-printer
 EXAMPLE_ENV=hello
+FOO=bar
+EXAMPLE_OVERRIDE=over
 ```
 
 _TODO: Exit codes_

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -47,7 +47,8 @@ func init() {
 	cmdPrepare.Flags.StringVar(&flagStage1Image, "stage1-image", defaultStage1Image, `image to use as stage1. Local paths and http/https URLs are supported. If empty, Rocket will look for a file called "stage1.aci" in the same directory as rkt itself`)
 	cmdPrepare.Flags.Var(&flagVolumes, "volume", "volumes to mount into the shared container environment")
 	cmdPrepare.Flags.BoolVar(&flagQuiet, "quiet", false, "suppress superfluous output on stdout, print only the UUID on success")
-	cmdPrepare.Flags.BoolVar(&flagInheritEnv, "inherit-environment", false, "inherit all environment variables not set by apps")
+	cmdPrepare.Flags.BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
+	cmdPrepare.Flags.Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 }
 
 func runPrepare(args []string) (exit int) {
@@ -119,6 +120,7 @@ func runPrepare(args []string) (exit int) {
 		ExecAppends: appArgs,
 		Volumes:     []types.Volume(flagVolumes),
 		InheritEnv:  flagInheritEnv,
+		ExplicitEnv: flagExplicitEnv.Strings(),
 	}
 
 	if err = stage0.Prepare(pcfg, c.path(), c.uuid); err != nil {


### PR DESCRIPTION
Also renamed --inherit-environment to --inherit-env, the former is too
verbose for consistent use with --set-env considering --set-env is to be
used repeatedly for multiple variables, abbreviate both uniformly.

This incarnation of --set-env applies set variables globally to all apps,
it seems desirable to be able to specify target apps for the variables.
Limiting inheritance to specific apps may also be useful.