### PR TITLE
rkt: include preparing containers when matching a uuid

### DIFF
--- a/rkt/uuid.go
+++ b/rkt/uuid.go
@@ -26,8 +26,7 @@ import (
 // matchUUID attempts to match the uuid specified as uuid against all containers present.
 // An array of matches is returned, which may be empty when nothing matches.
 func matchUUID(uuid string) ([]string, error) {
-	// TODO(vc): maybe switch this to use the uuidsDir instead (include embryos?)
-	ls, err := listContainers(includePreparedDir | includeRunDir | includeExitedGarbageDir)
+	ls, err := listContainers(includePrepareDir | includePreparedDir | includeRunDir | includeExitedGarbageDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Though the uuid isn't returned until `rkt prepare` completes, it's still
discoverable via `rkt list`, and `rkt status --wait a01b` should work if
a01b is in the preparing phase.