### PR TITLE
rkt: add support for --mounts to `rkt run` and `rkt prepare`

### DIFF
--- a/rkt/list.go
+++ b/rkt/list.go
@@ -32,12 +32,14 @@ var (
 		Usage:   "",
 		Run:     runList,
 	}
-	flagNoLegend bool
+	flagNoLegend   bool
+	flagLongOutput bool
 )
 
 func init() {
 	commands = append(commands, cmdList)
 	cmdList.Flags.BoolVar(&flagNoLegend, "no-legend", false, "suppress a legend with the list")
+	cmdList.Flags.BoolVar(&flagLongOutput, "long", false, "use long output format")
 }
 
 func runList(args []string) (exit int) {
@@ -70,7 +72,14 @@ func runList(args []string) (exit int) {
 			app_zero = m.Apps[0].Name.String()
 		}
 
-		fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\n", c.uuid, app_zero, c.getState(), fmtNets(c.nets))
+		uuid := ""
+		if flagLongOutput {
+			uuid = c.uuid.String()
+		} else {
+			uuid = c.uuid.String()[:8]
+		}
+
+		fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\n", uuid, app_zero, c.getState(), fmtNets(c.nets))
 		for i := 1; i < len(m.Apps); i++ {
 			fmt.Fprintf(tabOut, "\t%s\n", m.Apps[i].Name.String())
 		}

--- a/rkt/mounts.go
+++ b/rkt/mounts.go
@@ -1,0 +1,127 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+// volumeList implements the flag.Value interface to contain a set of mappings
+// from volume label --> mount path (for host type volumes)
+type volumeList []types.Volume
+
+func (vl *volumeList) Set(s string) error {
+	vol, err := types.VolumeFromString(s)
+	if err != nil {
+		return err
+	}
+
+	*vl = append(*vl, *vol)
+	return nil
+}
+
+func (vl *volumeList) String() string {
+	var vs []string
+	for _, v := range []types.Volume(*vl) {
+		vs = append(vs, v.String())
+	}
+	return strings.Join(vs, " ")
+}
+
+// mountsMap implements the flag.Value interface to contain a map of mount mappings
+// for associating app-specific mountpoints with volumes:
+// --mount app=APPNAME,volume=VOLNAME,target=MNTNAME
+type mountsMap map[types.ACName][]schema.Mount
+
+func (ml *mountsMap) Set(s string) error {
+	var appName *types.ACName
+	mount := schema.Mount{}
+
+	// this is intentionally made similar to types.VolumeFromString()
+	m, err := url.ParseQuery(strings.Replace(s, ",", "&", -1))
+	if err != nil {
+		return err
+	}
+
+	for key, val := range m {
+		if len(val) > 1 {
+			return fmt.Errorf("label %s with multiple values %q", key, val)
+		}
+		switch key {
+		case "app":
+			appName, err = types.NewACName(val[0])
+			if err != nil {
+				return err
+			}
+		case "volume":
+			mv, err := types.NewACName(val[0])
+			if err != nil {
+				return err
+			}
+			mount.Volume = *mv
+		case "target":
+			mp, err := types.NewACName(val[0])
+			if err != nil {
+				return err
+			}
+			mount.MountPoint = *mp
+		default:
+			return fmt.Errorf("unknown mount parameter %q", key)
+		}
+	}
+
+	// TODO(vc): this seems like quite the contortion, golang why must you hate me.
+	if *ml == nil {
+		*ml = make(map[types.ACName][]schema.Mount)
+	}
+	mm := map[types.ACName][]schema.Mount(*ml)
+
+	mm[*appName] = append(mm[*appName], mount)
+	return nil
+}
+
+func (ml *mountsMap) String() string {
+	// TODO(vc): return something meaningful
+	return ""
+}
+
+// Validate ensures all apps in ml exist in apps
+func (ml *mountsMap) ValidateAppNames(apps []*types.ACName) error {
+	dict := make(map[types.ACName]struct{})
+
+	for _, app := range apps {
+		dict[*app] = struct{}{}
+	}
+
+	for app, _ := range map[types.ACName][]schema.Mount(*ml) {
+		if _, exists := dict[app]; !exists {
+			return fmt.Errorf("app %q doesn't exist", app)
+		}
+	}
+	return nil
+}
+
+// GetAppMounts returns the mounts list for the named app
+func (ml *mountsMap) GetAppMounts(app *types.ACName) []schema.Mount {
+	m, _ := map[types.ACName][]schema.Mount(*ml)[*app]
+	return m
+}


### PR DESCRIPTION
This introduces the concept of requiring app names with images on
the cli:

$  rkt run --mount app=test,volume=foo,target=work \
  --volume foo,source=/tmp,kind=host test=imgs/mounter.aci

There needs to be a way to address the app instances, here we just require
unique names be provided.

To keep things simple and consistent, the name is always required, even for
trivial runs:
$ rkt run simple=imgs/pauser.aci

Things are mostly unchanged, just a name= is expected before the image now,
and that name is referred to by --mount to specify which app the mount
pertains to.

This will probably be utilized by --set-env for setting app-specific
variables, and anything else we need to permit setting app-specifically.