### PR TITLE
stage1: support interactive containers

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -54,10 +54,15 @@ func ContainerManifestPath(root string) string {
 	return filepath.Join(root, "container")
 }
 
+// AppImagesPath returns the path where the app images live
+func AppImagesPath(root string) string {
+	return filepath.Join(Stage1RootfsPath(root), stage2Dir)
+}
+
 // AppImagePath returns the path where an app image (i.e. unpacked ACI) is rooted (i.e.
 // where its contents are extracted during stage0), based on the app image ID.
 func AppImagePath(root string, imageID types.Hash) string {
-	return filepath.Join(Stage1RootfsPath(root), stage2Dir, types.ShortHash(imageID.String()))
+	return filepath.Join(AppImagesPath(root), types.ShortHash(imageID.String()))
 }
 
 // AppRootfsPath returns the path to an app's rootfs.

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -39,6 +39,7 @@ var (
 	flagSpawnMetadataService bool
 	flagInheritEnv           bool
 	flagExplicitEnv          envMap
+	flagInteractive          bool
 	cmdRun                   = &Command{
 		Name:    "run",
 		Summary: "Run image(s) in an application container in rocket",
@@ -70,6 +71,7 @@ func init() {
 	cmdRun.Flags.BoolVar(&flagSpawnMetadataService, "spawn-metadata-svc", false, "launch metadata svc if not running")
 	cmdRun.Flags.BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
 	cmdRun.Flags.Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
+	cmdRun.Flags.BoolVar(&flagInteractive, "interactive", false, "the container is interactive")
 	flagVolumes = volumeList{}
 }
 
@@ -174,6 +176,10 @@ func parseAppArgs(args []string) ([][]string, []string, error) {
 }
 
 func runRun(args []string) (exit int) {
+	if flagInteractive && len(args) > 1 {
+		stderr("run: interactive option only supports one image")
+		return 1
+	}
 	if globalFlags.Dir == "" {
 		log.Printf("dir unset - using temporary directory")
 		var err error
@@ -263,6 +269,7 @@ func runRun(args []string) (exit int) {
 		PrivateNet:           flagPrivateNet,
 		SpawnMetadataService: flagSpawnMetadataService,
 		LockFd:               lfd,
+		Interactive:          flagInteractive,
 	}
 	stage0.Run(rcfg, c.path()) // execs, never returns
 

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -68,6 +68,7 @@ type RunConfig struct {
 	PrivateNet           bool // container should have its own network stack
 	SpawnMetadataService bool // launch metadata service
 	LockFd               int  // lock file descriptor
+	Interactive          bool // whether the container is interactive or not
 }
 
 // configuration shared by both Run and Prepare
@@ -206,6 +207,9 @@ func Run(cfg RunConfig, dir string) {
 	}
 	if cfg.PrivateNet {
 		args = append(args, "--private-net")
+	}
+	if cfg.Interactive {
+		args = append(args, "--interactive")
 	}
 	if err := syscall.Exec(args[0], args, os.Environ()); err != nil {
 		log.Fatalf("error execing init: %v", err)

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -76,13 +76,15 @@ func mirrorLocalZoneInfo(root string) {
 }
 
 var (
-	debug   bool
-	privNet bool
+	debug       bool
+	privNet     bool
+	interactive bool
 )
 
 func init() {
 	flag.BoolVar(&debug, "debug", false, "Run in debug mode")
 	flag.BoolVar(&privNet, "private-net", false, "Setup private network (WIP!)")
+	flag.BoolVar(&interactive, "interactive", false, "The container is interactive")
 
 	// this ensures that main runs only on main thread (thread group leader).
 	// since namespace ops (unshare, setns) are done for a single thread, we
@@ -101,7 +103,7 @@ func stage1() int {
 	mirrorLocalZoneInfo(c.Root)
 	c.MetadataServiceURL = common.MetadataServicePublicURL()
 
-	if err = c.ContainerToSystemd(); err != nil {
+	if err = c.ContainerToSystemd(interactive); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to configure systemd: %v\n", err)
 		return 2
 	}


### PR DESCRIPTION
By using systemd's StandardInput option we set /dev/console in stage1
as the tty for the app (see systemd.exec(5)). This makes interactive
executables like bash work with rkt run (or prepare+run-prepared).

This is only supported if the container has only one app.

Fixes #562 