### PR TITLE
Godeps: bump appc to latest master

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -25,33 +25,33 @@
 		},
 		{
 			"ImportPath": "github.com/appc/spec/aci",
-			"Comment": "v0.4.0",
-			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
+			"Comment": "v0.4.0-10-g24650793e48a",
+			"Rev": "24650793e48a5a7fd04bf680e25c5ae192e4241d"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/actool",
-			"Comment": "v0.4.0",
-			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
+			"Comment": "v0.4.0-10-g24650793e48a",
+			"Rev": "24650793e48a5a7fd04bf680e25c5ae192e4241d"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/discovery",
-			"Comment": "v0.4.0",
-			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
+			"Comment": "v0.4.0-10-g24650793e48a",
+			"Rev": "24650793e48a5a7fd04bf680e25c5ae192e4241d"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/acirenderer",
-			"Comment": "v0.4.0",
-			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
+			"Comment": "v0.4.0-10-g24650793e48a",
+			"Rev": "24650793e48a5a7fd04bf680e25c5ae192e4241d"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/pkg/tarheader",
-			"Comment": "v0.4.0",
-			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
+			"Comment": "v0.4.0-10-g24650793e48a",
+			"Rev": "24650793e48a5a7fd04bf680e25c5ae192e4241d"
 		},
 		{
 			"ImportPath": "github.com/appc/spec/schema",
-			"Comment": "v0.4.0",
-			"Rev": "9d3d227e4cc6f505763b10addac8afcbd162cfe2"
+			"Comment": "v0.4.0-10-g24650793e48a",
+			"Rev": "24650793e48a5a7fd04bf680e25c5ae192e4241d"
 		},
 		{
 			"ImportPath": "github.com/camlistore/lock",

--- a/Godeps/_workspace/src/github.com/appc/spec/aci/file_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/aci/file_test.go
@@ -14,7 +14,7 @@ func newTestACI(usedotslash bool) (*os.File, error) {
 		return nil, err
 	}
 
-	manifestBody := `{"acKind":"ImageManifest","acVersion":"0.3.0","name":"example.com/app"}`
+	manifestBody := `{"acKind":"ImageManifest","acVersion":"0.4.0","name":"example.com/app"}`
 
 	gw := gzip.NewWriter(tf)
 	tw := tar.NewWriter(gw)

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/image_test.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/image_test.go
@@ -6,7 +6,7 @@ func TestEmptyApp(t *testing.T) {
 	imj := `
 		{
 		    "acKind": "ImageManifest",
-		    "acVersion": "0.3.0",
+		    "acVersion": "0.4.0",
 		    "name": "example.com/test"
 		}
 		`

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_linux_specific.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_linux_specific.go
@@ -6,17 +6,16 @@ import (
 )
 
 const (
-	LinuxCapabilitiesRetainSetName string = "os/linux/capabilities-retain-set"
-	LinuxCapabilitiesRevokeSetName string = "os/linux/capabilities-revoke-set"
+	LinuxCapabilitiesRetainSetName = "os/linux/capabilities-retain-set"
+	LinuxCapabilitiesRevokeSetName = "os/linux/capabilities-revoke-set"
 )
 
 func init() {
-	AddIsolatorValueConstructor(NewLinuxCapabilitiesRetainSet)
-	AddIsolatorValueConstructor(NewLinuxCapabilitiesRevokeSet)
+	AddIsolatorValueConstructor(LinuxCapabilitiesRetainSetName, NewLinuxCapabilitiesRetainSet)
+	AddIsolatorValueConstructor(LinuxCapabilitiesRevokeSetName, NewLinuxCapabilitiesRevokeSet)
 }
 
 type LinuxCapabilitiesSet interface {
-	Name() string
 	Set() []LinuxCapability
 	AssertValid() error
 }
@@ -61,18 +60,10 @@ type LinuxCapabilitiesRetainSet struct {
 	linuxCapabilitiesSetBase
 }
 
-func (l LinuxCapabilitiesRetainSet) Name() string {
-	return LinuxCapabilitiesRetainSetName
-}
-
 func NewLinuxCapabilitiesRevokeSet() IsolatorValue {
 	return &LinuxCapabilitiesRevokeSet{}
 }
 
 type LinuxCapabilitiesRevokeSet struct {
 	linuxCapabilitiesSetBase
-}
-
-func (l LinuxCapabilitiesRevokeSet) Name() string {
-	return LinuxCapabilitiesRevokeSetName
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_resources.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/types/isolator_resources.go
@@ -22,11 +22,11 @@ const (
 )
 
 func init() {
-	AddIsolatorValueConstructor(NewResourceBlockBandwidth)
-	AddIsolatorValueConstructor(NewResourceBlockIOPS)
-	AddIsolatorValueConstructor(NewResourceCPU)
-	AddIsolatorValueConstructor(NewResourceMemory)
-	AddIsolatorValueConstructor(NewResourceNetworkBandwidth)
+	AddIsolatorValueConstructor(ResourceBlockBandwidthName, NewResourceBlockBandwidth)
+	AddIsolatorValueConstructor(ResourceBlockIOPSName, NewResourceBlockIOPS)
+	AddIsolatorValueConstructor(ResourceCPUName, NewResourceCPU)
+	AddIsolatorValueConstructor(ResourceMemoryName, NewResourceMemory)
+	AddIsolatorValueConstructor(ResourceNetworkBandwidthName, NewResourceNetworkBandwidth)
 }
 
 func NewResourceBlockBandwidth() IsolatorValue {
@@ -93,10 +93,6 @@ func (r ResourceBlockBandwidth) AssertValid() error {
 	return nil
 }
 
-func (r ResourceBlockBandwidth) Name() string {
-	return ResourceBlockBandwidthName
-}
-
 type ResourceBlockIOPS struct {
 	ResourceBase
 }
@@ -111,10 +107,6 @@ func (r ResourceBlockIOPS) AssertValid() error {
 	return nil
 }
 
-func (r ResourceBlockIOPS) Name() string {
-	return ResourceBlockIOPSName
-}
-
 type ResourceCPU struct {
 	ResourceBase
 }
@@ -126,10 +118,6 @@ func (r ResourceCPU) AssertValid() error {
 	return nil
 }
 
-func (r ResourceCPU) Name() string {
-	return ResourceCPUName
-}
-
 type ResourceMemory struct {
 	ResourceBase
 }
@@ -139,10 +127,6 @@ func (r ResourceMemory) AssertValid() error {
 		return ErrDefaultTrue
 	}
 	return nil
-}
-
-func (r ResourceMemory) Name() string {
-	return ResourceMemoryName
 }
 
 type ResourceNetworkBandwidth struct {
@@ -157,8 +141,4 @@ func (r ResourceNetworkBandwidth) AssertValid() error {
 		return ErrRequestNonEmpty
 	}
 	return nil
-}
-
-func (r ResourceNetworkBandwidth) Name() string {
-	return ResourceNetworkBandwidthName
 }

--- a/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
+++ b/Godeps/_workspace/src/github.com/appc/spec/schema/version.go
@@ -8,7 +8,7 @@ const (
 	// version represents the canonical version of the appc spec and tooling.
 	// For now, the schema and tooling is coupled with the spec itself, so
 	// this must be kept in sync with the VERSION file in the root of the repo.
-	version string = "0.4.0"
+	version string = "0.4.0+git"
 )
 
 var (

--- a/stage1/init/container.go
+++ b/stage1/init/container.go
@@ -299,12 +299,11 @@ func (c *Container) appToNspawnArgs(ra *schema.RuntimeApp, am *schema.ImageManif
 		switch v := i.Value().(type) {
 		case types.LinuxCapabilitiesSet:
 			var caps []string
-			var s types.LinuxCapabilitiesSet = v
 			// TODO: cleanup the API on LinuxCapabilitiesSet to give strings easily.
 			for _, c := range v.Set() {
 				caps = append(caps, string(c))
 			}
-			if s.Name() == types.LinuxCapabilitiesRetainSetName {
+			if i.Name == types.LinuxCapabilitiesRetainSetName {
 				capList := strings.Join(caps, ",")
 				args = append(args, "--capability="+capList)
 			}


### PR DESCRIPTION
This is to capture the bugfix from https://github.com/appc/spec/pull/234

The real solution here is to fix https://github.com/appc/spec/pull/235, bump
the spec, and then vendor the new release, but rolling this in now so that
isolators are fixed on master.