### PR TITLE
Read only etc rkt

### DIFF
--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -139,7 +139,7 @@ func storeTrustedKey(dir string, r io.Reader) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", err
 	}
 	entityList, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(pubkeyBytes))


### PR DESCRIPTION
Lets make everything under `/etc/rkt` be 0755. This makes install work perfectly with the following workflow.

```
groupadd rocket
usermod -a -G rocket philips
sudo rkt install
sudo rkt trust --prefix coreos.com/etcd
rkt fetch coreos.com/etcd:v2.0.4
sudo rkt run coreos.com/etcd:v2.0.4
```