### PR TITLE
net: set FD_CLOEXEC on RktLock prior to fork/exec

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -18,7 +18,9 @@ package common
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/aci"
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
@@ -27,6 +29,8 @@ import (
 const (
 	stage1Dir = "/stage1"
 	stage2Dir = "/opt/stage2"
+
+	EnvLockFd = "RKT_LOCK_FD"
 
 	MetadataServiceIP      = "169.254.169.255"
 	MetadataServicePubPort = 80
@@ -97,4 +101,15 @@ func MetadataServicePrivateURL() string {
 // MetadataServicePublicURL returns the public URL used to host the metadata service
 func MetadataServicePublicURL() string {
 	return fmt.Sprintf("http://%v:%v", MetadataServiceIP, MetadataServicePubPort)
+}
+
+func GetRktLockFD() (int, error) {
+	if v := os.Getenv(EnvLockFd); v != "" {
+		fd, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return -1, err
+		}
+		return int(fd), nil
+	}
+	return -1, fmt.Errorf("%v env var is not set", EnvLockFd)
 }

--- a/networking/net_plugin.go
+++ b/networking/net_plugin.go
@@ -106,6 +106,7 @@ func (e *containerEnv) execNetPlugin(cmd string, n *Net, netns, args, ifName str
 		Stdout: stdout,
 		Stderr: os.Stderr,
 	}
+
 	if err := c.Run(); err != nil {
 		return nil, err
 	}

--- a/pkg/lock/dir.go
+++ b/pkg/lock/dir.go
@@ -153,8 +153,7 @@ func (l *DirLock) Close() error {
 func NewLock(dir string) (*DirLock, error) {
 	l := &DirLock{dir: dir, fd: -1}
 
-	// we can't use os.OpenFile as Go sets O_CLOEXEC
-	lfd, err := syscall.Open(l.dir, syscall.O_RDONLY|syscall.O_DIRECTORY, 0)
+	lfd, err := syscall.Open(l.dir, syscall.O_RDONLY|syscall.O_DIRECTORY|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		if err == syscall.ENOENT {
 			err = ErrNotExist

--- a/pkg/sys/sys.go
+++ b/pkg/sys/sys.go
@@ -1,0 +1,18 @@
+package sys
+
+import (
+	"syscall"
+)
+
+// CloseOnExec sets or clears FD_CLOEXEC flag on a file descriptor
+func CloseOnExec(fd int, set bool) error {
+	flag := uintptr(0)
+	if set {
+		flag = syscall.FD_CLOEXEC
+	}
+	_, _, err := syscall.RawSyscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_SETFD, flag)
+	if err != 0 {
+		return syscall.Errno(err)
+	}
+	return nil
+}

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -40,11 +40,8 @@ import (
 	"github.com/coreos/rocket/cas"
 	"github.com/coreos/rocket/common"
 	"github.com/coreos/rocket/pkg/aci"
+	"github.com/coreos/rocket/pkg/sys"
 	"github.com/coreos/rocket/version"
-)
-
-const (
-	envLockFd = "RKT_LOCK_FD"
 )
 
 // configuration parameters required by Prepare
@@ -176,7 +173,7 @@ func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
 // Run actually runs the prepared container by exec()ing the stage1 init inside
 // the container filesystem.
 func Run(cfg RunConfig, dir string) {
-	if err := os.Setenv(envLockFd, fmt.Sprintf("%v", cfg.LockFd)); err != nil {
+	if err := os.Setenv(common.EnvLockFd, fmt.Sprintf("%v", cfg.LockFd)); err != nil {
 		log.Fatalf("setting lock fd environment: %v", err)
 	}
 
@@ -208,6 +205,12 @@ func Run(cfg RunConfig, dir string) {
 	if cfg.Interactive {
 		args = append(args, "--interactive")
 	}
+
+	// make sure the lock fd stays open across exec
+	if err := sys.CloseOnExec(cfg.LockFd, false); err != nil {
+		log.Fatalf("error clearing FD_CLOEXEC on lock fd")
+	}
+
 	if err := syscall.Exec(args[0], args, os.Environ()); err != nil {
 		log.Fatalf("error execing init: %v", err)
 	}
@@ -293,5 +296,6 @@ func launchMetadataService(debug bool) error {
 		Stdout:     os.Stdout,
 		Stderr:     os.Stderr,
 	}
+
 	return cmd.Start()
 }


### PR DESCRIPTION
When launching metadata service and net plugins,
set the close-on-exec flag so the child processes
don't end up holding the lock.