### PR TITLE
rkt: support overlay filesystem

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -30,7 +30,8 @@ const (
 	stage1Dir = "/stage1"
 	stage2Dir = "/opt/stage2"
 
-	EnvLockFd = "RKT_LOCK_FD"
+	EnvLockFd        = "RKT_LOCK_FD"
+	Stage1IDFilename = "stage1ID"
 
 	MetadataServiceIP      = "169.254.169.255"
 	MetadataServicePubPort = 80

--- a/rkt/containers.go
+++ b/rkt/containers.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid"
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema"
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rocket/common"
 	"github.com/coreos/rocket/networking/netinfo"
@@ -699,14 +700,17 @@ func (c *container) getAppCount() (int, error) {
 		return -1, fmt.Errorf("error: only prepared containers can get their app count")
 	}
 
-	appsPath := common.AppImagesPath(".")
-
-	lapps, err := c.getDirNames(appsPath)
+	b, err := ioutil.ReadFile(common.ContainerManifestPath(c.path()))
 	if err != nil {
-		return -1, fmt.Errorf("error getting the list of names from %q: %v", appsPath, err)
+		return -1, fmt.Errorf("error reading container manifest: %v", err)
 	}
 
-	return len(lapps), nil
+	m := schema.ContainerRuntimeManifest{}
+	if err = m.UnmarshalJSON(b); err != nil {
+		return -1, fmt.Errorf("unable to load manifest: %v", err)
+	}
+
+	return len(m.Apps), nil
 }
 
 // getExitStatuses returns a map of the statuses of the container.

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -112,15 +112,15 @@ func runPrepare(args []string) (exit int) {
 
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: stage0.CommonConfig{
-			Store: ds,
-			Debug: globalFlags.Debug,
+			Store:       ds,
+			Debug:       globalFlags.Debug,
+			Stage1Image: *s1img,
+			Images:      imgs,
 		},
-		Stage1Image: *s1img,
-		Images:      imgs,
 		ExecAppends: appArgs,
-		Volumes:     []types.Volume(flagVolumes),
 		InheritEnv:  flagInheritEnv,
 		ExplicitEnv: flagExplicitEnv.Strings(),
+		Volumes:     []types.Volume(flagVolumes),
 	}
 
 	if err = stage0.Prepare(pcfg, c.path(), c.uuid); err != nil {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -232,14 +232,14 @@ func runRun(args []string) (exit int) {
 	}
 
 	cfg := stage0.CommonConfig{
-		Store: ds,
-		Debug: globalFlags.Debug,
+		Store:       ds,
+		Stage1Image: *s1img,
+		Images:      imgs,
+		Debug:       globalFlags.Debug,
 	}
 
 	pcfg := stage0.PrepareConfig{
 		CommonConfig: cfg,
-		Stage1Image:  *s1img,
-		Images:       imgs,
 		ExecAppends:  appArgs,
 		Volumes:      []types.Volume(flagVolumes),
 		InheritEnv:   flagInheritEnv,

--- a/rkt/run_prepared.go
+++ b/rkt/run_prepared.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"log"
 
-	//"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rocket/cas"
 	"github.com/coreos/rocket/stage0"
 )
@@ -108,10 +107,24 @@ func runRunPrepared(args []string) (exit int) {
 		return 1
 	}
 
+	s1img, err := c.getStage1Hash()
+	if err != nil {
+		stderr("prepared-run: unable to get stage1 Hash: %v", err)
+		return 1
+	}
+
+	imgs, err := c.getAppsHashes()
+	if err != nil {
+		stderr("prepared-run: unable to get apps hashes: %v", err)
+		return 1
+	}
+
 	rcfg := stage0.RunConfig{
 		CommonConfig: stage0.CommonConfig{
-			Store: ds,
-			Debug: globalFlags.Debug,
+			Store:       ds,
+			Stage1Image: *s1img,
+			Images:      imgs,
+			Debug:       globalFlags.Debug,
 		},
 		PrivateNet:           flagPrivateNet,
 		SpawnMetadataService: flagSpawnMetadataService,

--- a/stage0/enter.go
+++ b/stage0/enter.go
@@ -19,29 +19,23 @@ package stage0
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"syscall"
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
-	"github.com/coreos/rocket/common"
 )
 
 // Enter enters the container by exec()ing the stage1's /enter similar to /init
-// /enter can expect to have its CWD set to the container root
-// imageID and command are supplied to /enter on argv followed by any arguments
-func Enter(cdir string, imageID *types.Hash, cmdline []string) error {
+// /enter can expect to have its CWD set to the container root.
+// imageID and command are supplied to /enter on argv followed by any arguments.
+// enterPath is the path of the enter binary
+func Enter(cdir string, imageID *types.Hash, enterPath string, cmdline []string) error {
 	if err := os.Chdir(cdir); err != nil {
 		return fmt.Errorf("error changing to dir: %v", err)
 	}
 
 	id := types.ShortHash(imageID.String())
 
-	ep, err := getStage1Entrypoint(cdir, enterEntrypoint)
-	if err != nil {
-		return fmt.Errorf("error determining entrypoint: %v", err)
-	}
-
-	argv := []string{filepath.Join(common.Stage1RootfsPath(cdir), ep)}
+	argv := []string{enterPath}
 	argv = append(argv, id)
 	argv = append(argv, cmdline...)
 	if err := syscall.Exec(argv[0], argv, os.Environ()); err != nil {


### PR DESCRIPTION
This mounts stage1 and the application images as an overlay filesystem
using each ACI's cached tree as the lower filesystem.

Also, the mounts are done in a separate mount namespace so they will be
unmounted when the container exits and they're not visible by the rest
of the system.

Systems that don't support overlay fall back to plain copying.

Addresses #387 