### PR TITLE
Stage1 named apps

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -60,33 +60,32 @@ func AppImagesPath(root string) string {
 }
 
 // AppImagePath returns the path where an app image (i.e. unpacked ACI) is rooted (i.e.
-// where its contents are extracted during stage0), based on the app image ID.
-func AppImagePath(root string, imageID types.Hash) string {
-	return filepath.Join(AppImagesPath(root), types.ShortHash(imageID.String()))
+// where its contents are extracted during stage0), based on the app name.
+func AppImagePath(root string, appName *types.ACName) string {
+	return filepath.Join(AppImagesPath(root), appName.EscapedString())
 }
 
 // AppRootfsPath returns the path to an app's rootfs.
-// imageID should be the app image ID.
-func AppRootfsPath(root string, imageID types.Hash) string {
-	return filepath.Join(AppImagePath(root, imageID), aci.RootfsDir)
+// name should be the unique app name.
+func AppRootfsPath(root string, appName *types.ACName) string {
+	return filepath.Join(AppImagePath(root, appName), aci.RootfsDir)
 }
 
 // RelAppImagePath returns the path of an application image relative to the
 // stage1 chroot
-func RelAppImagePath(imageID types.Hash) string {
-	return filepath.Join(stage2Dir, types.ShortHash(imageID.String()))
+func RelAppImagePath(appName *types.ACName) string {
+	return filepath.Join(stage2Dir, appName.EscapedString())
 }
 
 // RelAppImagePath returns the path of an application's rootfs relative to the
 // stage1 chroot
-func RelAppRootfsPath(imageID types.Hash) string {
-	return filepath.Join(RelAppImagePath(imageID), aci.RootfsDir)
+func RelAppRootfsPath(appName *types.ACName) string {
+	return filepath.Join(RelAppImagePath(appName), aci.RootfsDir)
 }
 
 // ImageManifestPath returns the path to the app's manifest file inside the expanded ACI.
-// id should be the app image ID.
-func ImageManifestPath(root string, imageID types.Hash) string {
-	return filepath.Join(AppImagePath(root, imageID), aci.ManifestFile)
+func ImageManifestPath(root string, appName *types.ACName) string {
+	return filepath.Join(AppImagePath(root, appName), aci.ManifestFile)
 }
 
 // MetadataServicePrivateURL returns the private URL used to host the metadata service

--- a/rkt/containers.go
+++ b/rkt/containers.go
@@ -710,20 +710,25 @@ func (c *container) getAppCount() (int, error) {
 }
 
 // getExitStatuses returns a map of the statuses of the container.
-func (c *container) getExitStatuses() (map[string]int, error) {
+func (c *container) getExitStatuses() (map[types.ACName]int, error) {
 	ls, err := c.getDirNames(statusDir)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read status directory: %v", err)
 	}
 
-	stats := make(map[string]int)
-	for _, name := range ls {
-		s, err := c.readIntFromFile(filepath.Join(statusDir, name))
+	stats := make(map[types.ACName]int)
+	for _, escName := range ls {
+		name, err := types.EscapedNewACName(escName)
+		if err != nil {
+			stderr("Unable to create ACName from escaped %q: %v", escName, err)
+			continue
+		}
+		s, err := c.readIntFromFile(filepath.Join(statusDir, escName))
 		if err != nil {
 			stderr("Unable to get status of app %q: %v", name, err)
 			continue
 		}
-		stats[name] = s
+		stats[*name] = s
 	}
 	return stats, nil
 }

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -32,12 +32,14 @@ var (
 		Usage:   "",
 		Run:     runList,
 	}
-	flagNoLegend bool
+	flagNoLegend   bool
+	flagLongOutput bool
 )
 
 func init() {
 	commands = append(commands, cmdList)
 	cmdList.Flags.BoolVar(&flagNoLegend, "no-legend", false, "suppress a legend with the list")
+	cmdList.Flags.BoolVar(&flagLongOutput, "long", false, "use long output format")
 }
 
 func runList(args []string) (exit int) {
@@ -70,7 +72,14 @@ func runList(args []string) (exit int) {
 			app_zero = m.Apps[0].Name.String()
 		}
 
-		fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\n", c.uuid, app_zero, c.getState(), fmtNets(c.nets))
+		uuid := ""
+		if flagLongOutput {
+			uuid = c.uuid.String()
+		} else {
+			uuid = c.uuid.String()[:8]
+		}
+
+		fmt.Fprintf(tabOut, "%s\t%s\t%s\t%s\n", uuid, app_zero, c.getState(), fmtNets(c.nets))
 		for i := 1; i < len(m.Apps); i++ {
 			fmt.Fprintf(tabOut, "\t%s\n", m.Apps[i].Name.String())
 		}

--- a/rkt/mounts.go
+++ b/rkt/mounts.go
@@ -1,0 +1,127 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build linux
+
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+)
+
+// volumeList implements the flag.Value interface to contain a set of mappings
+// from volume label --> mount path (for host type volumes)
+type volumeList []types.Volume
+
+func (vl *volumeList) Set(s string) error {
+	vol, err := types.VolumeFromString(s)
+	if err != nil {
+		return err
+	}
+
+	*vl = append(*vl, *vol)
+	return nil
+}
+
+func (vl *volumeList) String() string {
+	var vs []string
+	for _, v := range []types.Volume(*vl) {
+		vs = append(vs, v.String())
+	}
+	return strings.Join(vs, " ")
+}
+
+// mountsMap implements the flag.Value interface to contain a map of mount mappings
+// for associating app-specific mountpoints with volumes:
+// --mount app=APPNAME,volume=VOLNAME,target=MNTNAME
+type mountsMap map[types.ACName][]schema.Mount
+
+func (ml *mountsMap) Set(s string) error {
+	var appName *types.ACName
+	mount := schema.Mount{}
+
+	// this is intentionally made similar to types.VolumeFromString()
+	m, err := url.ParseQuery(strings.Replace(s, ",", "&", -1))
+	if err != nil {
+		return err
+	}
+
+	for key, val := range m {
+		if len(val) > 1 {
+			return fmt.Errorf("label %s with multiple values %q", key, val)
+		}
+		switch key {
+		case "app":
+			appName, err = types.NewACName(val[0])
+			if err != nil {
+				return err
+			}
+		case "volume":
+			mv, err := types.NewACName(val[0])
+			if err != nil {
+				return err
+			}
+			mount.Volume = *mv
+		case "target":
+			mp, err := types.NewACName(val[0])
+			if err != nil {
+				return err
+			}
+			mount.MountPoint = *mp
+		default:
+			return fmt.Errorf("unknown mount parameter %q", key)
+		}
+	}
+
+	// TODO(vc): this seems like quite the contortion, golang why must you hate me.
+	if *ml == nil {
+		*ml = make(map[types.ACName][]schema.Mount)
+	}
+	mm := map[types.ACName][]schema.Mount(*ml)
+
+	mm[*appName] = append(mm[*appName], mount)
+	return nil
+}
+
+func (ml *mountsMap) String() string {
+	// TODO(vc): return something meaningful
+	return ""
+}
+
+// Validate ensures all apps in ml exist in apps
+func (ml *mountsMap) ValidateAppNames(apps []*types.ACName) error {
+	dict := make(map[types.ACName]struct{})
+
+	for _, app := range apps {
+		dict[*app] = struct{}{}
+	}
+
+	for app, _ := range map[types.ACName][]schema.Mount(*ml) {
+		if _, exists := dict[app]; !exists {
+			return fmt.Errorf("app %q doesn't exist", app)
+		}
+	}
+	return nil
+}
+
+// GetAppMounts returns the mounts list for the named app
+func (ml *mountsMap) GetAppMounts(app *types.ACName) []schema.Mount {
+	m, _ := map[types.ACName][]schema.Mount(*ml)[*app]
+	return m
+}

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -91,7 +91,7 @@ func printStatus(c *container) error {
 
 		stdout("pid=%d\nexited=%t", pid, c.isExited)
 		for app, stat := range stats {
-			stdout("%s=%d", app, stat)
+			stdout("app=%s=%d", app.String(), stat)
 		}
 	}
 	return nil

--- a/stage0/enter.go
+++ b/stage0/enter.go
@@ -28,13 +28,11 @@ import (
 
 // Enter enters the container by exec()ing the stage1's /enter similar to /init
 // /enter can expect to have its CWD set to the container root
-// imageID and command are supplied to /enter on argv followed by any arguments
-func Enter(cdir string, imageID *types.Hash, cmdline []string) error {
+// app and command are supplied to /enter on argv followed by any arguments
+func Enter(cdir string, app *types.ACName, cmdline []string) error {
 	if err := os.Chdir(cdir); err != nil {
 		return fmt.Errorf("error changing to dir: %v", err)
 	}
-
-	id := types.ShortHash(imageID.String())
 
 	ep, err := getStage1Entrypoint(cdir, enterEntrypoint)
 	if err != nil {
@@ -42,7 +40,7 @@ func Enter(cdir string, imageID *types.Hash, cmdline []string) error {
 	}
 
 	argv := []string{filepath.Join(common.Stage1RootfsPath(cdir), ep)}
-	argv = append(argv, id)
+	argv = append(argv, app.String())
 	argv = append(argv, cmdline...)
 	if err := syscall.Exec(argv[0], argv, os.Environ()); err != nil {
 		return fmt.Errorf("error execing enter: %v", err)

--- a/stage1/init/path.go
+++ b/stage1/init/path.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema"
 	"github.com/coreos/rocket/common"
 )
 
@@ -31,56 +31,56 @@ const (
 	socketsWantsDir = unitsDir + "/sockets.target.wants"
 )
 
-// ServiceUnitName returns a systemd service unit name for the given imageID
-func ServiceUnitName(imageID types.Hash) string {
-	return types.ShortHash(imageID.String()) + ".service"
+// ServiceUnitName returns a systemd service unit name for the given app
+func ServiceUnitName(app *schema.RuntimeApp) string {
+	return app.Name.EscapedString() + ".service"
 }
 
 // ServiceUnitPath returns the path to the systemd service file for the given
-// imageID
-func ServiceUnitPath(root string, imageID types.Hash) string {
-	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, ServiceUnitName(imageID))
+// app
+func ServiceUnitPath(root string, app *schema.RuntimeApp) string {
+	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, ServiceUnitName(app))
 }
 
-// RelEnvFilePath returns the path to the environment file for the given imageID
+// RelEnvFilePath returns the path to the environment file for the given app
 // relative to the container's root
-func RelEnvFilePath(imageID types.Hash) string {
-	return filepath.Join(envDir, types.ShortHash(imageID.String()))
+func RelEnvFilePath(app *schema.RuntimeApp) string {
+	return filepath.Join(envDir, app.Name.EscapedString())
 }
 
-// EnvFilePath returns the path to the environment file for the given imageID
-func EnvFilePath(root string, imageID types.Hash) string {
-	return filepath.Join(common.Stage1RootfsPath(root), RelEnvFilePath(imageID))
+// EnvFilePath returns the path to the environment file for the given app
+func EnvFilePath(root string, app *schema.RuntimeApp) string {
+	return filepath.Join(common.Stage1RootfsPath(root), RelEnvFilePath(app))
 }
 
 // ServiceWantPath returns the systemd default.target want symlink path for the
-// given imageID
-func ServiceWantPath(root string, imageID types.Hash) string {
-	return filepath.Join(common.Stage1RootfsPath(root), defaultWantsDir, ServiceUnitName(imageID))
+// given app
+func ServiceWantPath(root string, app *schema.RuntimeApp) string {
+	return filepath.Join(common.Stage1RootfsPath(root), defaultWantsDir, ServiceUnitName(app))
 }
 
 // InstantiatedPrepareAppUnitName returns the systemd service unit name for prepare-app
 // instantiated for the given root
-func InstantiatedPrepareAppUnitName(imageID types.Hash) string {
+func InstantiatedPrepareAppUnitName(app *schema.RuntimeApp) string {
 	// Naming respecting escaping rules, see systemd.unit(5) and systemd-escape(1)
-	escaped_root := common.RelAppRootfsPath(imageID)
+	escaped_root := common.RelAppRootfsPath(&app.Name)
 	escaped_root = strings.Replace(escaped_root, "-", "\\x2d", -1)
 	escaped_root = strings.Replace(escaped_root, "/", "-", -1)
 	return "prepare-app@" + escaped_root + ".service"
 }
 
-// SocketUnitName returns a systemd socket unit name for the given imageID
-func SocketUnitName(imageID types.Hash) string {
-	return imageID.String() + ".socket"
+// SocketUnitName returns a systemd socket unit name for the given app
+func SocketUnitName(app *schema.RuntimeApp) string {
+	return app.Name.EscapedString() + ".socket"
 }
 
-// SocketUnitPath returns the path to the systemd socket file for the given imageID
-func SocketUnitPath(root string, imageID types.Hash) string {
-	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, SocketUnitName(imageID))
+// SocketUnitPath returns the path to the systemd socket file for the given app
+func SocketUnitPath(root string, app *schema.RuntimeApp) string {
+	return filepath.Join(common.Stage1RootfsPath(root), unitsDir, SocketUnitName(app))
 }
 
 // SocketWantPath returns the systemd sockets.target.wants symlink path for the
-// given imageID
-func SocketWantPath(root string, imageID types.Hash) string {
-	return filepath.Join(common.Stage1RootfsPath(root), socketsWantsDir, SocketUnitName(imageID))
+// given app
+func SocketWantPath(root string, app *schema.RuntimeApp) string {
+	return filepath.Join(common.Stage1RootfsPath(root), socketsWantsDir, SocketUnitName(app))
 }

--- a/stage1/init/registration.go
+++ b/stage1/init/registration.go
@@ -39,7 +39,7 @@ func registerContainer(c *Container, ip net.IP) error {
 
 	uid := c.Manifest.UUID.String()
 	for _, app := range c.Manifest.Apps {
-		ampath := common.ImageManifestPath(c.Root, app.Image.ID)
+		ampath := common.ImageManifestPath(c.Root, &app.Name)
 		amf, err := os.Open(ampath)
 		if err != nil {
 			fmt.Errorf("failed reading app manifest %q: %v", ampath, err)


### PR DESCRIPTION
last commit is the interesting one

https://github.com/coreos/rocket/commit/5ff80210305aa58eb126400ca0c7abdad465bcf1 this depends on was met with some resistance/criticism, but I imagine the overall spirit of the change is the general direction we're headed.  We need to use these unique app identifiers in stage1 instead of the image identifiers, particularly when we can instantiate the same image multiple times in a single container.  The naming of things may need change depending on what happens with --mounts, but I think the overall direction is correct-ish.  It seems like it was a mistake to ever allow such a tight coupling of app:image.

Travis will fail due to dependency on https://github.com/appc/spec/pull/247 for escaping type.ACName