### PR TITLE
stage1: Override image manifest's readOnly field for volume mounts.

### DIFF
--- a/stage1/init/container.go
+++ b/stage1/init/container.go
@@ -288,7 +288,14 @@ func (c *Container) appToNspawnArgs(ra *schema.RuntimeApp, am *schema.ImageManif
 		}
 		opt := make([]string, 4)
 
-		if mp.ReadOnly {
+		// If the readonly flag in the pod manifest is not nil,
+		// then use it to override the readonly flag in the image manifest.
+		readOnly := mp.ReadOnly
+		if vol.ReadOnly != nil {
+			readOnly = *vol.ReadOnly
+		}
+
+		if readOnly {
 			opt[0] = "--bind-ro="
 		} else {
 			opt[0] = "--bind="

--- a/stage1/init/container_test.go
+++ b/stage1/init/container_test.go
@@ -15,7 +15,11 @@
 package main
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema"
+	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 )
 
 func TestQuoteExec(t *testing.T) {
@@ -42,6 +46,83 @@ func TestQuoteExec(t *testing.T) {
 		o := quoteExec(tt.input)
 		if o != tt.output {
 			t.Errorf("#%d: expected `%v` got `%v`", i, tt.output, o)
+		}
+	}
+}
+
+// TestAppToNspawnArgsOverridesImageManifestReadOnly tests
+// that the ImageManifest's `readOnly` volume setting will be
+// overrided by PodManifest.
+func TestAppToNspawnArgsOverridesImageManifestReadOnly(t *testing.T) {
+	falseVar := false
+	trueVar := true
+	tests := []struct {
+		imageManifestVolumeReadOnly bool
+		podManifestVolumeReadOnly   *bool
+		expectReadOnly              bool
+	}{
+		{
+			false,
+			nil,
+			false,
+		},
+		{
+			false,
+			&falseVar,
+			false,
+		},
+		{
+			false,
+			&trueVar,
+			true,
+		},
+		{
+			true,
+			nil,
+			true,
+		},
+		{
+			true,
+			&falseVar,
+			false,
+		},
+		{
+			true,
+			&trueVar,
+			true,
+		},
+	}
+
+	for i, tt := range tests {
+		imageManifest := &schema.ImageManifest{
+			App: &types.App{
+				MountPoints: []types.MountPoint{
+					{
+						Name:     "foo-mount",
+						Path:     "/app/foo",
+						ReadOnly: tt.imageManifestVolumeReadOnly,
+					},
+				},
+			},
+		}
+		podManifest := &schema.PodManifest{
+			Volumes: []types.Volume{
+				{
+					Name:     "foo-mount",
+					Kind:     "host",
+					Source:   "/host/foo",
+					ReadOnly: tt.podManifestVolumeReadOnly,
+				},
+			},
+		}
+
+		c := &Container{Manifest: podManifest}
+		output, err := c.appToNspawnArgs(&schema.RuntimeApp{}, imageManifest)
+		if err != nil {
+			t.Errorf("#%d: unexpected error: `%v`", i, err)
+		}
+		if ro := strings.HasPrefix(output[0], "--bind-ro"); ro != tt.expectReadOnly {
+			t.Errorf("#%d: expected: readOnly: %v, saw: %v", i, tt.expectReadOnly, ro)
 		}
 	}
 }


### PR DESCRIPTION
Fix #615 