### PR TITLE
stage1: prepare-app: prepare /dev/pts for apps

### DIFF
--- a/stage1/rootfs/prepare-app/prepare-app.c
+++ b/stage1/rootfs/prepare-app/prepare-app.c
@@ -68,6 +68,12 @@ int main(int argc, char *argv[])
 		"/dev/console",
 		NULL
 	};
+	static const char *bind_dirs[] = {
+		"/proc",
+		"/sys",
+		"/dev/shm",
+		NULL
+	};
 	const char *root;
 	int rootfd;
 	char to[4096];
@@ -154,23 +160,15 @@ int main(int argc, char *argv[])
 				"Mounting \"%s\" on \"%s\" failed", from, to);
 	}
 
-	/* /proc */
-	exit_if(snprintf(to, sizeof(to), "%s/proc", root) >= sizeof(to),
-		"Path too long: \"%s\"", to);
-	pexit_if(mount("/proc", to, "bind", MS_BIND, NULL) == -1,
-			"Mounting /proc on \"%s\" failed", to);
+	/* Bind mount directories */
+	for (i = 0; bind_dirs[i]; i++) {
+		const char *from = bind_dirs[i];
 
-	/* /sys */
-	exit_if(snprintf(to, sizeof(to), "%s/sys", root) >= sizeof(to),
-		"Path too long: \"%s\"", to);
-	pexit_if(mount("/sys", to, "bind", MS_BIND, NULL) == -1,
-			"Mounting /sys on \"%s\" failed", to);
-
-	/* /dev/shm */
-	exit_if(snprintf(to, sizeof(to), "%s/dev/shm", root) >= sizeof(to),
-		"Path too long: \"%s\"", to);
-	pexit_if(mount("/dev/shm", to, "bind", MS_BIND, NULL) == -1,
-			"Mounting /dev/shm on \"%s\" failed", to);
+		exit_if(snprintf(to, sizeof(to), "%s/%s", root, from) >= sizeof(to),
+			"Path too long: \"%s\"", to);
+		pexit_if(mount(from, to, "bind", MS_BIND, NULL) == -1,
+				"Mounting \"%s\" on \"%s\" failed", from, to);
+	}
 
 	return EXIT_SUCCESS;
 }

--- a/stage1/rootfs/prepare-app/prepare-app.c
+++ b/stage1/rootfs/prepare-app/prepare-app.c
@@ -47,6 +47,7 @@ int main(int argc, char *argv[])
 {
 	static const char *unlink_paths[] = {
 		"dev/shm",
+		"dev/ptmx",
 		NULL
 	};
 	static const dir_op_t dirs[] = {

--- a/stage1/rootfs/prepare-app/prepare-app.c
+++ b/stage1/rootfs/prepare-app/prepare-app.c
@@ -56,6 +56,7 @@ int main(int argc, char *argv[])
 		dir("proc",	0755),
 		dir("sys",	0755),
 		dir("tmp",	01777),
+		dir("dev/pts",	0755),
 	};
 	static const char *devnodes[] = {
 		"/dev/null",
@@ -72,6 +73,7 @@ int main(int argc, char *argv[])
 		"/proc",
 		"/sys",
 		"/dev/shm",
+		"/dev/pts",
 		NULL
 	};
 	const char *root;
@@ -169,6 +171,12 @@ int main(int argc, char *argv[])
 		pexit_if(mount(from, to, "bind", MS_BIND, NULL) == -1,
 				"Mounting \"%s\" on \"%s\" failed", from, to);
 	}
+
+	/* /dev/ptmx -> /dev/pts/ptmx */
+	exit_if(snprintf(to, sizeof(to), "%s/dev/ptmx", root) >= sizeof(to),
+		"Path too long: \"%s\"", to);
+	pexit_if(symlink("/dev/pts/ptmx", to) == -1,
+		"Failed to create /dev/ptmx symlink");
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Interactive containers expect /dev/pts.

Also, make /dev/ptmx a symlink to /dev/pts/ptmx.
See https://www.kernel.org/doc/Documentation/filesystems/devpts.txt