### PR TITLE
rkt: check that at least one endpoint has been discovered.

### DIFF
--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -101,6 +101,11 @@ func fetchImage(img string, ds *cas.Store, ks *keystore.Keystore, discover bool)
 			if err != nil {
 				return "", err
 			}
+
+			if len(ep.ACIEndpoints) == 0 {
+				return "", fmt.Errorf("no endpoints discovered")
+			}
+
 			latest := false
 			// No specified version label, mark it as latest
 			if _, ok := app.Labels["version"]; !ok {


### PR DESCRIPTION
Or it will panic calling fetchImageFromEndpoints.

By now appc/spec discovery.DiscoverEndpoints doesn't return an error if no endpoints are found. I'm not sure if this is a wanted behavior or should be fixed there.

In past I proposed PR #382 that will automatically avoid this as it iterates over all the endpoints. 