### PR TITLE
rkt: fix status with overlay

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -30,8 +30,9 @@ const (
 	stage1Dir = "/stage1"
 	stage2Dir = "/opt/stage2"
 
-	EnvLockFd        = "RKT_LOCK_FD"
-	Stage1IDFilename = "stage1ID"
+	EnvLockFd               = "RKT_LOCK_FD"
+	Stage1IDFilename        = "stage1ID"
+	OverlayPreparedFilename = "overlay-prepared"
 
 	MetadataServiceIP      = "169.254.169.255"
 	MetadataServicePubPort = 80

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -27,8 +27,9 @@ var (
 )
 
 const (
-	statusDir     = "stage1/rootfs/rkt/status"
-	cmdStatusName = "status"
+	overlayStatusDirTemplate = "overlay/%s/upper/rkt/status"
+	regularStatusDir         = "stage1/rootfs/rkt/status"
+	cmdStatusName            = "status"
 )
 
 func init() {

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -47,10 +47,6 @@ import (
 	"github.com/coreos/rocket/version"
 )
 
-const (
-	overlayFilename = "overlay-prepared"
-)
-
 // configuration parameters required by Prepare
 type PrepareConfig struct {
 	CommonConfig
@@ -187,7 +183,7 @@ func Prepare(cfg PrepareConfig, dir string, uuid *types.UUID) error {
 
 	if useOverlay {
 		// mark the pod as prepared with overlay
-		f, err := os.Create(filepath.Join(dir, overlayFilename))
+		f, err := os.Create(filepath.Join(dir, common.OverlayPreparedFilename))
 		if err != nil {
 			return fmt.Errorf("error writing overlay marker file: %v", err)
 		}
@@ -217,7 +213,7 @@ func supportsOverlay() bool {
 }
 
 func preparedWithOverlay(dir string) (bool, error) {
-	_, err := os.Stat(filepath.Join(dir, overlayFilename))
+	_, err := os.Stat(filepath.Join(dir, common.OverlayPreparedFilename))
 	if os.IsNotExist(err) {
 		return false, nil
 	}


### PR DESCRIPTION
When using overlay fs rkt status stopped working because it searched for
the status file in the stage1 rootfs, which is either in a different
mount namespace or unmounted.

If the container uses overlay fs, we now search in its upper layer,
which is accessible outside the mount namespace or when the filesystem
is not mounted.

Fixes #665 