### PR TITLE
Vagrant: Bug no squashfs-tools.

### DIFF
--- a/scripts/vagrant/install-rocket.sh
+++ b/scripts/vagrant/install-rocket.sh
@@ -16,6 +16,8 @@ if ! [ -d app-spec ]; then
   popd
 fi
 
+which unsquash || sudo apt-get install -y squashfs-tools
+
 pushd /vagrant
 ./build
 


### PR DESCRIPTION
Last change introduced in issue where the
squashfs tools were no longer installed if missing.

This corrects that issue