### PR TITLE
common: rename PodManifest: "container" -> "pod"

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -57,7 +57,7 @@ func Stage1ManifestPath(root string) string {
 
 // PodManifestPath returns the path in root to the Pod Manifest
 func PodManifestPath(root string) string {
-	return filepath.Join(root, "container")
+	return filepath.Join(root, "pod")
 }
 
 // AppImagesPath returns the path where the app images live


### PR DESCRIPTION
This was breaking prepare/run-prepared because it expected the file to
be named "pod".  Rename it accordingly.