### PR TITLE
stage0: fix overlay dir permissions 0700 -> 0755

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -442,16 +442,16 @@ func overlayRender(cfg RunConfig, img types.Hash, cdir string, dest string) erro
 	cachedTreePath := cfg.Store.GetTreeStoreRootFS(img.String())
 
 	overlayDir := path.Join(cdir, "overlay", img.String())
-	if err := os.MkdirAll(overlayDir, 0700); err != nil {
+	if err := os.MkdirAll(overlayDir, 0755); err != nil {
 		return err
 	}
 
 	upperDir := path.Join(overlayDir, "upper")
-	if err := os.MkdirAll(upperDir, 0700); err != nil {
+	if err := os.MkdirAll(upperDir, 0755); err != nil {
 		return err
 	}
 	workDir := path.Join(overlayDir, "work")
-	if err := os.MkdirAll(workDir, 0700); err != nil {
+	if err := os.MkdirAll(workDir, 0755); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Having the permissions of overlay, upper and work dirs set to 0700 makes
"/" in the container have 0700 permissions, which breaks images that try
to execute files as different users.