### PR TITLE
rkt: fix enter when running without overlay fs

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -382,17 +382,17 @@ func prepareStage1Image(cfg PrepareConfig, img types.Hash, cdir string, useOverl
 		return fmt.Errorf("error creating stage1 directory: %v", err)
 	}
 
-	if useOverlay {
-		if err := cfg.Store.RenderTreeStore(img.String(), false); err != nil {
+	if err := cfg.Store.RenderTreeStore(img.String(), false); err != nil {
+		return fmt.Errorf("error rendering tree image: %v", err)
+	}
+	if err := cfg.Store.CheckTreeStore(img.String()); err != nil {
+		log.Printf("Warning: tree cache is in a bad state. Rebuilding...")
+		if err := cfg.Store.RenderTreeStore(img.String(), true); err != nil {
 			return fmt.Errorf("error rendering tree image: %v", err)
 		}
-		if err := cfg.Store.CheckTreeStore(img.String()); err != nil {
-			log.Printf("Warning: tree cache is in a bad state. Rebuilding...")
-			if err := cfg.Store.RenderTreeStore(img.String(), true); err != nil {
-				return fmt.Errorf("error rendering tree image: %v", err)
-			}
-		}
-	} else {
+	}
+
+	if !useOverlay {
 		if err := aci.RenderACIWithImageID(img, s1, cfg.Store); err != nil {
 			return fmt.Errorf("error rendering ACI: %v", err)
 		}


### PR DESCRIPTION
When not using overlay fs, the tree cache was not getting populated.
Since we now take the enter binary from the tree cache, this was
breaking rkt enter.

We now populate stage1's tree cache in every case. We don't do it for
the app images because it can add a significant amount of time in the
first run if the image is big and it's not needed unless you use overlay
fs.

Fixes #683