### PR TITLE
stage1: bump acVersion

### DIFF
--- a/stage1/rootfs/aggregate/aci-manifest
+++ b/stage1/rootfs/aggregate/aci-manifest
@@ -1,6 +1,6 @@
 {
     "acKind": "ImageManifest",
-    "acVersion": "0.2.0",
+    "acVersion": "0.5.1",
     "name": "coreos.com/rocket/stage1",
     "labels": [
         {


### PR DESCRIPTION
This has little significance until we start keying off version numbers, but might as well keep it in sync for now.