### PR TITLE
rkt: add --no-overlay option

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -17,8 +17,10 @@
 package common
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 
@@ -110,4 +112,24 @@ func GetRktLockFD() (int, error) {
 		return int(fd), nil
 	}
 	return -1, fmt.Errorf("%v env var is not set", EnvLockFd)
+}
+
+// SupportsOverlay returns whether the system supports overlay filesystem
+func SupportsOverlay() bool {
+	exec.Command("modprobe", "overlay").Run()
+
+	f, err := os.Open("/proc/filesystems")
+	if err != nil {
+		fmt.Println("error opening /proc/filesystems")
+		return false
+	}
+	defer f.Close()
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if s.Text() == "nodev\toverlay" {
+			return true
+		}
+	}
+	return false
 }

--- a/rkt/prepare.go
+++ b/rkt/prepare.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rocket/cas"
+	"github.com/coreos/rocket/common"
 	"github.com/coreos/rocket/stage0"
 )
 
@@ -48,6 +49,7 @@ func init() {
 	cmdPrepare.Flags.Var(&flagVolumes, "volume", "volumes to mount into the shared container environment")
 	cmdPrepare.Flags.BoolVar(&flagQuiet, "quiet", false, "suppress superfluous output on stdout, print only the UUID on success")
 	cmdPrepare.Flags.BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
+	cmdPrepare.Flags.BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	cmdPrepare.Flags.Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 }
 
@@ -122,6 +124,7 @@ func runPrepare(args []string) (exit int) {
 		InheritEnv:  flagInheritEnv,
 		ExplicitEnv: flagExplicitEnv.Strings(),
 		Volumes:     []types.Volume(flagVolumes),
+		UseOverlay:  !flagNoOverlay && common.SupportsOverlay(),
 	}
 
 	if err = stage0.Prepare(pcfg, c.path(), c.uuid); err != nil {

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coreos/rocket/Godeps/_workspace/src/github.com/appc/spec/schema/types"
 	"github.com/coreos/rocket/cas"
+	"github.com/coreos/rocket/common"
 	"github.com/coreos/rocket/pkg/keystore"
 	"github.com/coreos/rocket/stage0"
 )
@@ -40,6 +41,7 @@ var (
 	flagInheritEnv           bool
 	flagExplicitEnv          envMap
 	flagInteractive          bool
+	flagNoOverlay            bool
 	cmdRun                   = &Command{
 		Name:    "run",
 		Summary: "Run image(s) in an application container in rocket",
@@ -70,6 +72,7 @@ func init() {
 	cmdRun.Flags.BoolVar(&flagPrivateNet, "private-net", false, "give container a private network")
 	cmdRun.Flags.BoolVar(&flagSpawnMetadataService, "spawn-metadata-svc", false, "launch metadata svc if not running")
 	cmdRun.Flags.BoolVar(&flagInheritEnv, "inherit-env", false, "inherit all environment variables not set by apps")
+	cmdRun.Flags.BoolVar(&flagNoOverlay, "no-overlay", false, "disable overlay filesystem")
 	cmdRun.Flags.Var(&flagExplicitEnv, "set-env", "an environment variable to set for apps in the form name=value")
 	cmdRun.Flags.BoolVar(&flagInteractive, "interactive", false, "the container is interactive")
 	flagVolumes = volumeList{}
@@ -245,6 +248,7 @@ func runRun(args []string) (exit int) {
 		Volumes:      []types.Volume(flagVolumes),
 		InheritEnv:   flagInheritEnv,
 		ExplicitEnv:  flagExplicitEnv.Strings(),
+		UseOverlay:   !flagNoOverlay && common.SupportsOverlay(),
 	}
 	err = stage0.Prepare(pcfg, c.path(), c.uuid)
 	if err != nil {


### PR DESCRIPTION
Adds an option to not disable overlay filesystem.

Since this option is listed in https://github.com/coreos/rocket/releases/tag/v0.5.1 I thought it'd be nice to actually have it :P. I called it `--no-overlay` because that's the official name of the filesystem.