### PR TITLE
mdsvc: no more 169.254.169.255 address

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -19,6 +19,7 @@ package common
 import (
 	"bufio"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,9 +37,7 @@ const (
 	Stage1IDFilename        = "stage1ID"
 	OverlayPreparedFilename = "overlay-prepared"
 
-	MetadataServiceIP      = "169.254.169.255"
-	MetadataServicePubPort = 80
-	MetadataServicePrvPort = 2375
+	MetadataServicePort    = 2375
 	MetadataServiceRegSock = "/run/rkt/metadata-svc.sock"
 )
 
@@ -99,8 +98,8 @@ func ImageManifestPath(root string, imageID types.Hash) string {
 }
 
 // MetadataServicePublicURL returns the public URL used to host the metadata service
-func MetadataServicePublicURL() string {
-	return fmt.Sprintf("http://%v:%v", MetadataServiceIP, MetadataServicePubPort)
+func MetadataServicePublicURL(ip net.IP) string {
+	return fmt.Sprintf("http://%v:%v", ip, MetadataServicePort)
 }
 
 func GetRktLockFD() (int, error) {

--- a/networking/net/net.go
+++ b/networking/net/net.go
@@ -63,6 +63,10 @@ func LoadNet(path string, n interface{}) error {
 type IfConfig struct {
 	IP  gonet.IP `json:"ip,omitempty"`
 	IP6 gonet.IP `json:"ip6,omitempty"`
+
+	// these are "extensions" and only meaningful for default net
+	HostIP  gonet.IP `json:"hostIP,omitempty"`
+	HostIP6 gonet.IP `json:"hostIP6,omitempty"`
 }
 
 func PrintIfConfig(conf *IfConfig) error {

--- a/networking/net/veth/veth.go
+++ b/networking/net/veth/veth.go
@@ -116,7 +116,8 @@ func cmdAdd(args *util.CmdArgs) error {
 	}
 
 	return rktnet.PrintIfConfig(&rktnet.IfConfig{
-		IP: ipConf.IP.IP,
+		IP:     ipConf.IP.IP,
+		HostIP: ipConf.Gateway,
 	})
 }
 

--- a/networking/net_plugin.go
+++ b/networking/net_plugin.go
@@ -32,18 +32,18 @@ import (
 const UserNetPluginsPath = "/usr/lib/rkt/plugins/net"
 const BuiltinNetPluginsPath = "usr/lib/rkt/plugins/net"
 
-func (e *containerEnv) netPluginAdd(n *Net, netns, args, ifName string) (net.IP, error) {
+func (e *containerEnv) netPluginAdd(n *Net, netns, args, ifName string) (ip, hostIP net.IP, err error) {
 	output, err := e.execNetPlugin("ADD", n, netns, args, ifName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	ifConf := rktnet.IfConfig{}
 	if err = json.Unmarshal(output, &ifConf); err != nil {
-		return nil, fmt.Errorf("error parsing %q output: %v", n.Name, err)
+		return nil, nil, fmt.Errorf("error parsing %q output: %v", n.Name, err)
 	}
 
-	return ifConf.IP, nil
+	return ifConf.IP, ifConf.HostIP, nil
 }
 
 func (e *containerEnv) netPluginDel(n *Net, netns, args, ifName string) error {

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -39,6 +39,7 @@ type activeNet struct {
 	Net
 	ifName string
 	ip     net.IP
+	hostIP net.IP // kludge for default network
 }
 
 // "base" struct that's populated from the beginning
@@ -54,6 +55,7 @@ type Networking struct {
 	containerEnv
 
 	MetadataIP net.IP
+	HostIP     net.IP
 
 	contID     types.UUID
 	hostNS     *os.File
@@ -112,6 +114,7 @@ func Setup(rktRoot string, contID types.UUID) (*Networking, error) {
 
 	// last net is the default
 	n.MetadataIP = n.nets[len(n.nets)-1].ip
+	n.HostIP = n.nets[len(n.nets)-1].hostIP
 
 	return &n, nil
 }
@@ -197,7 +200,7 @@ func (e *containerEnv) setupNets(netns string, nets []Net) ([]activeNet, error) 
 			break
 		}
 
-		an.ip, err = e.netPluginAdd(&nt, netns, nt.args, an.ifName)
+		an.ip, an.hostIP, err = e.netPluginAdd(&nt, netns, nt.args, an.ifName)
 		if err != nil {
 			err = fmt.Errorf("error adding network %q: %v", nt.Name, err)
 			break


### PR DESCRIPTION
Since the spec requires AC_METADATA_URL env var,
well known IP is no longer needed. This removes
the iptables manipulation. Instead the IP address of the
host is passed in the AC_METADATA_URL. This host IP
is the address of the host end of the default veth.