### PR TITLE
fetch: download does not use correct tmpdir during tests

### DIFF
--- a/cas/cas.go
+++ b/cas/cas.go
@@ -139,15 +139,19 @@ func NewStore(base string) (*Store, error) {
 	return ds, nil
 }
 
-func (ds Store) tmpFile() (*os.File, error) {
-	dir, err := ds.tmpDir()
+// TmpFile returns an *os.File local to the same filesystem as the Store, or
+// any error encountered
+func (ds Store) TmpFile() (*os.File, error) {
+	dir, err := ds.TmpDir()
 	if err != nil {
 		return nil, err
 	}
 	return ioutil.TempFile(dir, "")
 }
 
-func (ds Store) tmpDir() (string, error) {
+// TmpDir creates and returns dir local to the same filesystem as the Store,
+// or any error encountered
+func (ds Store) TmpDir() (string, error) {
 	dir := filepath.Join(ds.base, "tmp")
 	if err := os.MkdirAll(dir, defaultPathPerm); err != nil {
 		return "", err
@@ -231,7 +235,7 @@ func (ds Store) WriteACI(r io.Reader, latest bool) (string, error) {
 	// tee so we can generate the hash
 	h := sha512.New()
 	tr := io.TeeReader(dr, h)
-	fh, err := ds.tmpFile()
+	fh, err := ds.TmpFile()
 	if err != nil {
 		return "", fmt.Errorf("error creating image: %v", err)
 	}

--- a/rkt/fetch_test.go
+++ b/rkt/fetch_test.go
@@ -262,7 +262,7 @@ func TestFetchImage(t *testing.T) {
 	defer ts.Close()
 	_, err = fetchImage(fmt.Sprintf("%s/app.aci", ts.URL), ds, ks, true)
 	if err != nil {
-		t.Fatalf("unexpected error %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
```
--- FAIL: TestDownloading (0.01s)
	fetch_test.go:188: error downloading aci: error downloading the aci image: error downloading ACI: open /var/lib/rkt/tmp/691547836: permission denied
```

This was introduced in https://github.com/coreos/rocket/commit/835787be94ce668b788ed47e6c1e8c0358dcf932 , which introduced a new `tmpDir()` helper unassociated with the cas. Unfortunately that means that even though we initialise the cas with a [custom tmpdir in the test](https://github.com/coreos/rocket/blob/190ba4257d668c3a38b733c20d99d9cc909e51c3/rkt/fetch_test.go#L170), the download function [still relies on the global directory argument](https://github.com/coreos/rocket/blob/190ba4257d668c3a38b733c20d99d9cc909e51c3/rkt/fetch.go#L361).